### PR TITLE
Ignore / when mount/umount/check mountpoint

### DIFF
--- a/cli/command/check.go
+++ b/cli/command/check.go
@@ -23,6 +23,8 @@
 package command
 
 import (
+	"strings"
+
 	"github.com/opencurve/curveadm/cli/cli"
 	"github.com/opencurve/curveadm/internal/tasks/client"
 	"github.com/opencurve/curveadm/internal/tasks/task"
@@ -52,7 +54,7 @@ func NewCheckCommand(curveadm *cli.CurveAdm) *cobra.Command {
 }
 
 func runCheck(curveadm *cli.CurveAdm, options checkOptions) error {
-	mountPoint := options.mountPoint
+	mountPoint := strings.TrimSuffix(options.mountPoint, "/")
 
 	if t, err := client.NewGetMountStatusTask(curveadm, mountPoint); err != nil {
 		return err

--- a/cli/command/mount.go
+++ b/cli/command/mount.go
@@ -24,6 +24,7 @@ package command
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/opencurve/curveadm/cli/cli"
 	"github.com/opencurve/curveadm/internal/configure"
@@ -67,7 +68,7 @@ func NewMountCommand(curveadm *cli.CurveAdm) *cobra.Command {
 }
 
 func runMount(curveadm *cli.CurveAdm, options mountOptions) error {
-	mountPoint := options.mountPoint
+	mountPoint := strings.TrimSuffix(options.mountPoint, "/")
 	mountFSName := options.mountFSName
 
 	if !utils.PathExist(mountPoint) {

--- a/cli/command/umount.go
+++ b/cli/command/umount.go
@@ -23,6 +23,8 @@
 package command
 
 import (
+	"strings"
+
 	"github.com/opencurve/curveadm/cli/cli"
 	"github.com/opencurve/curveadm/internal/tasks/client"
 	"github.com/opencurve/curveadm/internal/tasks/task"
@@ -52,7 +54,7 @@ func NewUmountCommand(curveadm *cli.CurveAdm) *cobra.Command {
 }
 
 func runUmount(curveadm *cli.CurveAdm, options umountOptions) error {
-	mountPoint := options.mountPoint
+	mountPoint := strings.TrimSuffix(options.mountPoint, "/")
 
 	if t, err := client.NewUmountFSTask(curveadm, mountPoint); err != nil {
 		return err


### PR DESCRIPTION
We get different result when check /mnt/curve-fuse/ and /mnt/curve-fuse,
we want to get the same result of this command, fix this issue by triming
the / suffix of mountpoint during mount/umount/check.

Fixes: #19