### PR TITLE
add warning for damage operations

### DIFF
--- a/cli/command/clean.go
+++ b/cli/command/clean.go
@@ -104,8 +104,9 @@ func runClean(curveadm *cli.CurveAdm, options cleanOptions) error {
 	}
 
 	// clean service
-	curveadm.WriteOut("clean: role=%s host=%s id=%s only=%s\n", role, host, id, strings.Join(only, ","))
-	if pass := tui.ConfirmYes("Do you want to continue? [y/N]: "); !pass {
+	curveadm.WriteOut("Warning: clean role=%s host=%s id=%s only=%s now, %s in it will be cleaned.\n",
+				role, host, id, strings.Join(only, ","), strings.Join(only, ","))
+	if pass := tui.ConfirmYes("Do you want to continue? [YES/No]: "); !pass {
 		curveadm.WriteOut("Clean canceled\n")
 		return nil
 	}

--- a/cli/command/cluster/remove.go
+++ b/cli/command/cluster/remove.go
@@ -66,7 +66,9 @@ func runRemove(curveadm *cli.CurveAdm, options removeOptions) error {
 	}
 
 	// TODO(@Wine93): check all service has removed before delete cluster
-	if pass := common.ConfirmYes("Do you want to continue? [y/N]: "); !pass {
+	curveadm.WriteOut("Warning: This operation will remove cluster %s, and all data in it will be cleaned.\n", clusterName)
+	if pass := common.ConfirmYes("Do you want to continue? [YES/No]: "); !pass {
+		curveadm.WriteOut("Remove cluster canceled\n")
 		return nil
 	} else if err := curveadm.Storage().DeleteCluster(clusterName); err != nil {
 		return err

--- a/cli/command/config/commit.go
+++ b/cli/command/config/commit.go
@@ -103,7 +103,7 @@ func runCommit(curveadm *cli.CurveAdm, options commitOptions) error {
 
 	if err := validateTopology(oldData, newData); err != nil {
 		return err
-	} else if pass := common.ConfirmYes("Do you want to continue? [y/N]: "); !pass {
+	} else if pass := common.ConfirmYes("Do you want to continue? [YES/No]: "); !pass {
 		return nil
 	} else if err := curveadm.Storage().SetClusterTopology(curveadm.ClusterId(), newData); err != nil {
 		return err

--- a/cli/command/stop.go
+++ b/cli/command/stop.go
@@ -28,6 +28,7 @@ import (
 	"github.com/opencurve/curveadm/cli/cli"
 	"github.com/opencurve/curveadm/internal/configure/topology"
 	"github.com/opencurve/curveadm/internal/task/tasks"
+	tui "github.com/opencurve/curveadm/internal/tui/common"
 	cliutil "github.com/opencurve/curveadm/internal/utils"
 	"github.com/spf13/cobra"
 )
@@ -73,7 +74,16 @@ func runStop(curveadm *cli.CurveAdm, options stopOptions) error {
 
 	if len(dcs) == 0 {
 		return fmt.Errorf("service not found")
-	} else if err := tasks.ExecTasks(tasks.STOP_SERVICE, curveadm, dcs); err != nil {
+	}
+
+	// stop service
+	curveadm.WriteOut("Warning: Stop all service now, client IO will be hang!\n")
+	if pass := tui.ConfirmYes("Do you want to continue? [YES/No]: "); !pass {
+		curveadm.WriteOut("Stop canceled\n")
+		return nil
+	}
+
+	if err := tasks.ExecTasks(tasks.STOP_SERVICE, curveadm, dcs); err != nil {
 		return curveadm.NewPromptError(err, "")
 	}
 	return nil

--- a/cli/command/support.go
+++ b/cli/command/support.go
@@ -143,7 +143,7 @@ func runSupport(curveadm *cli.CurveAdm, options supportOptions) error {
 	}
 
 	curveadm.WriteOut(color.YellowString(PROMPT))
-	if pass := common.ConfirmYes("Do you want to continue? [y/N]: "); !pass {
+	if pass := common.ConfirmYes("Do you want to continue? [YES/No]: "); !pass {
 		return nil
 	}
 

--- a/internal/tools/upgrade.go
+++ b/internal/tools/upgrade.go
@@ -80,7 +80,7 @@ func Upgrade(curveadm *cli.CurveAdm) error {
 	} else if yes {
 		curveadm.WriteOut("The current version is up-to-date\n")
 		return nil
-	} else if pass := tui.ConfirmYes("Upgrade curveadm to v%s? [y/N]: ", v[0]); !pass {
+	} else if pass := tui.ConfirmYes("Upgrade curveadm to v%s? [YES/No]: ", v[0]); !pass {
 		return nil
 	}
 

--- a/internal/tui/common/tui.go
+++ b/internal/tui/common/tui.go
@@ -142,9 +142,9 @@ func ConfirmNo(format string, a ...interface{}) bool {
 }
 
 func ConfirmYes(format string, a ...interface{}) bool {
-	ans := prompt(fmt.Sprintf(format, a...) + "(default=N)")
-	switch strings.TrimSpace(strings.ToLower(ans)) {
-	case "y", "yes":
+	ans := prompt(fmt.Sprintf(format, a...) + "(default=No)")
+	switch strings.TrimSpace(ans) {
+	case "YES":
 		return true
 	default:
 		return false


### PR DESCRIPTION
Closing #13 

```
$ curveadm cluster rm fs
Warning: This operation will remove cluster fs, and all data in it will be cleaned.
Do you want to continue? [YES/No]: (default=No) YES
Deleted cluster 'fs'

$ curveadm clean
Warning: clean role=* host=* id=* only=log,data,container now, log,data,container in it will be cleaned.
Do you want to continue? [YES/No]: (default=No) YES

Clean Service: [OK]


$ curveadm stop
Warning: Stop all service now, client IO will be hang!
Do you want to continue? [YES/No]: (default=No) YES
Stop Service: [OK]
```