### PR TITLE
curveadm/mount: fix path same

### DIFF
--- a/internal/configure/client/fs/client.go
+++ b/internal/configure/client/fs/client.go
@@ -160,8 +160,8 @@ func (c *ClientConfig) GetClientConfPath() string {
 	return fmt.Sprintf("%s/client/conf/client.conf", LAYOUT_CURVEFS_ROOT_DIR)
 }
 
-func (c *ClientConfig) GetClientMountPath() string {
-	return fmt.Sprintf("%s/client/mnt", LAYOUT_CURVEFS_ROOT_DIR)
+func (c *ClientConfig) GetClientMountPath(subPath string) string {
+	return fmt.Sprintf("%s/client/mnt%s", LAYOUT_CURVEFS_ROOT_DIR, subPath)
 }
 
 func (c *ClientConfig) GetCoreLocateDir() string {

--- a/internal/task/task/common/create_pool.go
+++ b/internal/task/task/common/create_pool.go
@@ -59,7 +59,7 @@ func genCreatePoolCommand(dc *topology.DeployConfig, pooltype, poolJSONPath stri
 	toolsBinaryPath := layout.ToolsBinaryPath
 	if dc.GetKind() == topology.KIND_CURVEFS {
 		// for curvefs, the default topology json path is current directory's topology.json
-		return fmt.Sprintf("%s build-topology", toolsBinaryPath)
+		return fmt.Sprintf("%s create-topology", toolsBinaryPath)
 	}
 
 	return fmt.Sprintf("%s -op=create_%s -cluster_map=%s",

--- a/internal/task/task/fs/mount.go
+++ b/internal/task/task/fs/mount.go
@@ -56,9 +56,9 @@ var (
 	}
 )
 
-func getMountCommand(cc *client.ClientConfig, mountFSName string) string {
+func getMountCommand(cc *client.ClientConfig, mountFSName string, mountPoint string) string {
 	format := strings.Join(FORMAT_FUSE_ARGS, " ")
-	fuseArgs := fmt.Sprintf(format, mountFSName, cc.GetClientConfPath(), cc.GetClientMountPath())
+	fuseArgs := fmt.Sprintf(format, mountFSName, cc.GetClientConfPath(), cc.GetClientMountPath(mountPoint))
 	return fmt.Sprintf("/client.sh %s --role=client --args='%s'", mountFSName, fuseArgs)
 }
 
@@ -145,7 +145,7 @@ func NewMountFSTask(curvradm *cli.CurveAdm, cc *client.ClientConfig) (*task.Task
 	var containerId string
 	root := cc.GetCurveFSPrefix()
 	prefix := cc.GetClientPrefix()
-	containerMountPath := cc.GetClientMountPath()
+	containerMountPath := cc.GetClientMountPath(mountPoint)
 	createfsScript := scripts.SCRIPT_CREATEFS
 	createfsScriptPath := "/client.sh"
 	t.AddStep(&step.PullImage{
@@ -155,7 +155,7 @@ func NewMountFSTask(curvradm *cli.CurveAdm, cc *client.ClientConfig) (*task.Task
 	})
 	t.AddStep(&step.CreateContainer{
 		Image:             cc.GetContainerImage(),
-		Command:           getMountCommand(cc, mountFSName),
+		Command:           getMountCommand(cc, mountFSName, mountPoint),
 		Entrypoint:        "/bin/bash",
 		Envs:              []string{"LD_PRELOAD=/usr/local/lib/libjemalloc.so"},
 		Name:              mountPoint2ContainerName(mountPoint),


### PR DESCRIPTION
fix mountpoint same in container:
treat /curvefs/client/mnt as the prefix of the mount path Mount into the
container