### PR TITLE
script/creatfs: fix create-fs error but show ok

### DIFF
--- a/internal/task/scripts/createfs.go
+++ b/internal/task/scripts/createfs.go
@@ -43,5 +43,7 @@ createfs "$@"
 
 if [ $? -eq 0 ]; then
     $g_entrypoint "$@"
+else
+    exit 1
 fi
 `

--- a/internal/task/step/container.go
+++ b/internal/task/step/container.go
@@ -69,6 +69,7 @@ type (
 		ContainerId   *string
 		ExecWithSudo  bool
 		ExecInLocal   bool
+		ExecAttach    bool
 		ExecSudoAlias string
 	}
 
@@ -208,9 +209,13 @@ func (s *CreateContainer) Execute(ctx *context.Context) error {
 
 func (s *StartContainer) Execute(ctx *context.Context) error {
 	cli := ctx.Module().DockerCli().StartContainer(*s.ContainerId)
+	if s.ExecAttach {
+		cli.AddOption("--attach")
+	}
 	_, err := cli.Execute(module.ExecOption{
 		ExecWithSudo:  s.ExecWithSudo,
 		ExecInLocal:   s.ExecInLocal,
+		ExecAttach:    s.ExecAttach,
 		ExecSudoAlias: s.ExecSudoAlias,
 	})
 	return err

--- a/internal/task/task/fs/mount.go
+++ b/internal/task/task/fs/mount.go
@@ -206,6 +206,7 @@ func NewMountFSTask(curvradm *cli.CurveAdm, cc *client.ClientConfig) (*task.Task
 		ContainerId:   &containerId,
 		ExecWithSudo:  false,
 		ExecInLocal:   true,
+		ExecAttach:    true,
 		ExecSudoAlias: curvradm.SudoAlias(),
 	})
 

--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -37,6 +37,7 @@ type ExecOption struct {
 	ExecWithSudo  bool
 	ExecInLocal   bool
 	ExecSudoAlias string
+	ExecAttach    bool
 }
 
 type Module struct {


### PR DESCRIPTION
when create-fs fail the script wouldn't return error code

if docker start container without --attach, will return 0,
add attach flag in start container, when mount set it true