### PR TITLE
curvebs: fix mount status check fail during format chunkserver

### DIFF
--- a/internal/task/step/shell.go
+++ b/internal/task/step/shell.go
@@ -173,8 +173,8 @@ func (s *UmountFilesystem) Execute(ctx *context.Context) error {
 		})
 
 		out = strings.TrimSuffix(out, "\n")
-		if (s.IgnoreUmounted && strings.HasSuffix(out, ERR_NOT_MOUNTED)) ||
-			(s.IgnoreNotFound && strings.HasSuffix(out, ERR_MOUNTPOINT_NOT_FOUND)) {
+		if (s.IgnoreUmounted && strings.Contains(out, ERR_NOT_MOUNTED)) ||
+			(s.IgnoreNotFound && strings.Contains(out, ERR_MOUNTPOINT_NOT_FOUND)) {
 			continue
 		} else if err != nil {
 			return err


### PR DESCRIPTION
Closes: #55

When data dir is umounted, the check will failed on CentOS, because
we check suffix must be 'not mounted', but on CentOS it is 'not mounted.',
then the format will be failed.