### PR TITLE
feature(curvebs): support flexible format.yaml

### DIFF
--- a/configs/bs/cluster/format.yaml
+++ b/configs/bs/cluster/format.yaml
@@ -6,6 +6,14 @@ host:
   - 10.0.1.2
   - 10.0.1.3
 disk:
+  # support disk range like: /dev/sd[b-e]:/data/chunkserver[1-4]:90
+  # if you want to exclude disk /dev/sdc and sdd, use this:
+  #   /dev/sd[b-e,^cd]:/data/chunkserver[1-2]:80
+  # if you have too many disks on a host(more than 26), use these:
+  #   /dev/sd[a-z]:/data/chunkserver[1-26]:70
+  #   /dev/sda[a-z]:/data/chunkserver[27-52]:60
+  # also support disk and mountpoint with suffix, like:
+  #   /dev/nvme[0-9]n1:/data/chunkserver[0-9]n1:90
   - /dev/sda:/data/chunkserver0:90  # device:mount_path:format_percent%
   - /dev/sdb:/data/chunkserver1:90
   - /dev/sdc:/data/chunkserver2:90

--- a/configs/bs/stand-alone/format.yaml
+++ b/configs/bs/stand-alone/format.yaml
@@ -4,6 +4,14 @@ private_key_file: /home/curve/.ssh/publish_rsa
 host:
   - 10.0.1.1
 disk:
+  # support disk range like: /dev/sd[b-e]:/data/chunkserver[1-4]:90
+  # if you want to exclude disk /dev/sdc and sdd, use this:
+  #   /dev/sd[b-e,^cd]:/data/chunkserver[1-2]:80
+  # if you have too many disks on a host(more than 26), use these:
+  #   /dev/sd[a-z]:/data/chunkserver[1-26]:70
+  #   /dev/sda[a-z]:/data/chunkserver[27-52]:60
+  # also support disk and mountpoint with suffix, like:
+  #   /dev/nvme[0-9]n1:/data/chunkserver[0-9]n1:90
   - /dev/sda:/data/chunkserver0:90  # device:mount_path:format_percent%
   - /dev/sdb:/data/chunkserver1:90
   - /dev/sdc:/data/chunkserver2:90

--- a/internal/configure/format/format.go
+++ b/internal/configure/format/format.go
@@ -75,7 +75,6 @@ func ParseFormat(filename string) ([]*FormatConfig, error) {
 	fcs := []*FormatConfig{}
 	for _, host := range format.Hosts {
 		for _, disk := range format.Disks {
-			// /dev/sda:/data/chunkserver0:90
 			items := strings.Split(disk, ":")
 			if len(items) != 3 {
 				return nil, fmt.Errorf("'%s': invalid disk format", disk)
@@ -85,17 +84,87 @@ func ParseFormat(filename string) ([]*FormatConfig, error) {
 				return nil, fmt.Errorf("'%s': invalid disk format", disk)
 			}
 
-			fc := &FormatConfig{
-				Host:           host,
-				User:           format.User,
-				SSHPort:        format.SSHPort,
-				PrivateKeyFile: format.PrivateKeyFile,
-				ContainerIamge: containerImage,
-				Device:         items[0],
-				MountPoint:     items[1],
-				UsagePercent:   usagePercent,
+			// /dev/sd[h-k]:/data/chunkserver[5-8]:70
+			// /dev/sd[a-d,^bc]:/data/chunkserver[1-2]:90
+			// only support one disk letter in range,
+			// unsupport [aa-ad], use /dev/sda[a-d] instead.
+			// only support digist in mount point range, eg. /data/chunkserver[10-20]
+			if strings.Contains(disk, "[") {
+				diskList := items[0]                        // disks in range: /dev/sd[a-d,^bc] or /dev/sd[h-k]
+				start := strings.Index(diskList, "[") + 1   // index of start disk letter('a' or 'h') in range
+				end := strings.Index(diskList, "]")         // index of end disk letter('d' or 'k') in range
+				diskSeq := diskList[start:end]              // get a-d,^bc or h-k
+				disks := strings.Split(diskSeq, ",")        // split include disks and exclude disks
+				includeDisks := strings.TrimSpace(disks[0]) // get a-d or h-k
+				excludeDisks := ""
+				var excludes []rune
+				// get exclude disks: bc
+				if len(disks) == 2 {
+					excludeDisks = strings.TrimSpace(disks[1])[1:] // remove ^ and space
+					excludes = []rune(excludeDisks)
+				}
+				disks = strings.Split(includeDisks, "-")         // split include disk range: [a d] or [h k]
+				s := []rune(disks[0])[0]                         // get a or h
+				e := []rune(disks[1])[0]                         // get d or k
+				diskCount := int(e) - int(s) + 1 - len(excludes) // calc disk count in device range
+
+				// get /data/chunkserver[5-8] or /data/chunkserver[1-2]
+				mountPoints := items[1]
+				startm := strings.Index(mountPoints, "[") + 1                          // get index of 5 or 1
+				endm := strings.Index(mountPoints, "]")                                // get index of 8 or 2
+				mps := strings.Split(strings.TrimSpace(mountPoints[startm:endm]), "-") // get [5 8] or [1 2]
+				sm, _ := utils.Str2Int(strings.TrimSpace(mps[0]))                      // transfer string to int
+				em, _ := utils.Str2Int(strings.TrimSpace(mps[1]))                      // transfer string to int
+
+				// disk count is not equal to mountpoint count
+				// eg. /dev/sd[a-b]:/data/chunkserver[1-3]:70
+				if diskCount != (em - sm + 1) {
+					return nil, fmt.Errorf("'%s': invalid disk format, disk count does not match mount point count", disk)
+				}
+				// add all disks in range(pop exclude disks)
+				for ; s <= e; s++ {
+					find := false
+					for _, ex := range excludes {
+						// find the disk letter in exclude disks
+						if s == ex {
+							find = true
+							break
+						}
+					}
+					// disk not in excludes, add it
+					if !find {
+						device := diskList[:start-1] + string(s) + diskList[end+1:]          // /dev/sd + a + suffix
+						mp := mountPoints[:startm-1] + utils.Atoa(sm) + mountPoints[endm+1:] // /data/chunkserver + 1 + suffix
+						sm++                                                                 // next mount point number
+						fc := &FormatConfig{
+							Host:           host,
+							User:           format.User,
+							SSHPort:        format.SSHPort,
+							PrivateKeyFile: format.PrivateKeyFile,
+							ContainerIamge: containerImage,
+							Device:         device,
+							MountPoint:     mp,
+							UsagePercent:   usagePercent,
+						}
+						fcs = append(fcs, fc)
+					}
+				}
+			} else {
+				// /dev/sda:/data/chunkserver0:90
+				// single disk, add it
+				fc := &FormatConfig{
+					Host:           host,
+					User:           format.User,
+					SSHPort:        format.SSHPort,
+					PrivateKeyFile: format.PrivateKeyFile,
+					ContainerIamge: containerImage,
+					Device:         items[0],
+					MountPoint:     items[1],
+					UsagePercent:   usagePercent,
+				}
+				fcs = append(fcs, fc)
 			}
-			fcs = append(fcs, fc)
+
 		}
 	}
 	return fcs, nil


### PR DESCRIPTION
Close #60 

```
support disk range like: /dev/sd[b-e]:/data/chunkserver[1-4]:90
if you want to exclude disk /dev/sdc and sdd, use this:
  /dev/sd[b-e,^cd]:/data/chunkserver[1-2]:80
if you have too many disks on a host(more than 26), use these:
  /dev/sd[a-z]:/data/chunkserver[1-26]:70
  /dev/sda[a-z]:/data/chunkserver[27-52]:60
also support disk and mountpoint with suffix, like:
  /dev/nvme[0-9]n1:/data/chunkserver[0-9]n1:90
```