### PR TITLE
add cluster name to audit log

### DIFF
--- a/cli/curveadm.go
+++ b/cli/curveadm.go
@@ -53,9 +53,9 @@ func Execute() {
 	}
 
 	if res != nil {
-		log.Error(strings.Join(os.Args[1:], " "), log.Field("result", "failed"))
+		log.Error(strings.Join(os.Args[1:], " "), log.Field("Cluster", curveadm.ClusterName()), log.Field("result", "failed"))
 		os.Exit(1)
 	} else {
-		log.Info(strings.Join(os.Args[1:], " "), log.Field("result", "success"))
+		log.Info(strings.Join(os.Args[1:], " "), log.Field("Cluster", curveadm.ClusterName()), log.Field("result", "success"))
 	}
 }


### PR DESCRIPTION

```
# old audit log format:
[curve@localhost curveadm]$ cat ~/.curveadm/logs/curveadm-audit-2022-03-22.log
[2022/03/22 09:48:16.486 +08:00] [INFO] [curveadm.go:59] [status] [result=success]

# new audit log format:
[curve@localhost curveadm]$ cat ~/.curveadm/logs/curveadm-audit-2022-03-24.log
[2022/03/24 09:37:35.073 +08:00] [INFO] [curveadm.go:59] [status] [Cluster=mybs] [result=success]

```