### PR TITLE
display listening ports for each service when uses curveadm status

### DIFF
--- a/cli/command/cluster/list.go
+++ b/cli/command/cluster/list.go
@@ -31,7 +31,7 @@ import (
 )
 
 type listOptions struct {
-	vebose bool
+	verbose bool
 }
 
 func NewListCommand(curveadm *cli.CurveAdm) *cobra.Command {
@@ -49,7 +49,7 @@ func NewListCommand(curveadm *cli.CurveAdm) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.BoolVarP(&options.vebose, "verbose", "v", false, "Verbose output for clusters")
+	flags.BoolVarP(&options.verbose, "verbose", "v", false, "Verbose output for clusters")
 
 	return cmd
 }
@@ -62,7 +62,7 @@ func runList(curveadm *cli.CurveAdm, options listOptions) error {
 		return err
 	}
 
-	output := tui.FormatClusters(clusters, options.vebose)
+	output := tui.FormatClusters(clusters, options.verbose)
 	curveadm.WriteOut(output)
 	return nil
 }

--- a/cli/command/status.go
+++ b/cli/command/status.go
@@ -41,7 +41,7 @@ type statusOptions struct {
 	id          string
 	role        string
 	host        string
-	vebose      bool
+	verbose     bool
 	showReplica bool
 }
 
@@ -62,7 +62,7 @@ func NewStatusCommand(curveadm *cli.CurveAdm) *cobra.Command {
 	flags.StringVarP(&options.id, "id", "", "*", "Specify service id")
 	flags.StringVarP(&options.role, "role", "", "*", "Specify service role")
 	flags.StringVarP(&options.host, "host", "", "*", "Specify service host")
-	flags.BoolVarP(&options.vebose, "verbose", "v", false, "Verbose output for status")
+	flags.BoolVarP(&options.verbose, "verbose", "v", false, "Verbose output for status")
 	flags.BoolVarP(&options.showReplica, "show-replica", "s", false, "Display replica service")
 
 	return cmd
@@ -137,8 +137,12 @@ func runStatus(curveadm *cli.CurveAdm, options statusOptions) error {
 		Role: options.role,
 		Host: options.host,
 	})
-
-	if err := tasks.ExecTasks(tasks.GET_SERVICE_STATUS, curveadm, dcs); err != nil {
+	if options.verbose {
+		err = tasks.ExecTasks(tasks.GET_SERVICE_STATUS_DETAIL, curveadm, dcs)
+	} else {
+		err = tasks.ExecTasks(tasks.GET_SERVICE_STATUS, curveadm, dcs)
+	}
+	if err != nil {
 		return curveadm.NewPromptError(err, "Did you deploy the cluster?")
 	}
 
@@ -150,7 +154,7 @@ func runStatus(curveadm *cli.CurveAdm, options statusOptions) error {
 		statuses = append(statuses, status)
 	}
 
-	output := tui.FormatStatus(statuses, options.vebose, options.showReplica)
+	output := tui.FormatStatus(statuses, options.verbose, options.showReplica)
 	curveadm.WriteOut("\n")
 	curveadm.WriteOut("cluster name    : %s\n", curveadm.ClusterName())
 	curveadm.WriteOut("cluster kind    : %s\n", dcs[0].GetKind())

--- a/internal/task/tasks/items.go
+++ b/internal/task/tasks/items.go
@@ -71,6 +71,7 @@ const (
 	RESTART_SERVICE
 	CREATE_POOL
 	GET_SERVICE_STATUS
+	GET_SERVICE_STATUS_DETAIL
 	CLEAN_SERVICE
 	SYNC_BINARY
 	COLLECT_SERVICE
@@ -225,7 +226,11 @@ func ExecTasks(taskType int, curveadm *cli.CurveAdm, configSlice interface{}) er
 		case GET_SERVICE_STATUS:
 			option.SilentSubBar = true
 			option.SkipError = true
-			t, err = comm.NewGetServiceStatusTask(curveadm, dc)
+			t, err = comm.NewGetServiceStatusTask(curveadm, dc, false)
+		case GET_SERVICE_STATUS_DETAIL:
+			option.SilentSubBar = true
+			option.SkipError = true
+			t, err = comm.NewGetServiceStatusTask(curveadm, dc, true)
 		case CLEAN_SERVICE:
 			t, err = comm.NewCleanServiceTask(curveadm, dc)
 		case COLLECT_SERVICE:

--- a/internal/tui/clusters.go
+++ b/internal/tui/clusters.go
@@ -35,9 +35,9 @@ func currentDecorate(message string) string {
 	return color.GreenString(message)
 }
 
-func FormatClusters(clusters []storage.Cluster, vebose bool) string {
+func FormatClusters(clusters []storage.Cluster, verbose bool) string {
 	lines := [][]interface{}{}
-	if vebose {
+	if verbose {
 		title := []string{" ", "Cluster", "Id", "UUId", "Create Time", "Description"}
 		first, second := tuicommon.FormatTitle(title)
 		second[0] = ""
@@ -56,7 +56,7 @@ func FormatClusters(clusters []storage.Cluster, vebose bool) string {
 			line = append(line, cluster.Name)
 		}
 
-		if vebose {
+		if verbose {
 			line = append(line, strconv.Itoa(cluster.Id))
 			line = append(line, cluster.UUId)
 			line = append(line, cluster.CreateTime.Format("2006-01-02 15:04:05"))
@@ -67,7 +67,7 @@ func FormatClusters(clusters []storage.Cluster, vebose bool) string {
 	}
 
 	nspace := 1
-	if vebose {
+	if verbose {
 		nspace = 2
 	}
 	output := common.FixedFormat(lines, nspace)

--- a/internal/tui/service/status.go
+++ b/internal/tui/service/status.go
@@ -251,8 +251,9 @@ func FormatStatus(statuses []task.ServiceStatus, vebose, expand bool) string {
 	// cut column
 	locate := utils.Locate(title)
 	if !vebose {
-		tui.CutColumn(lines, locate["Data Dir"]) // Data Dir
-		tui.CutColumn(lines, locate["Log Dir"])  // Log Dir
+		tui.CutColumn(lines, locate["Listen Port"]) // Listen Port
+		tui.CutColumn(lines, locate["Data Dir"])    // Data Dir
+		tui.CutColumn(lines, locate["Log Dir"])     // Log Dir
 	}
 
 	output := tui.FixedFormat(lines, 2)

--- a/internal/tui/service/status.go
+++ b/internal/tui/service/status.go
@@ -210,7 +210,7 @@ func mergeStatues(statuses []task.ServiceStatus) []task.ServiceStatus {
 	return ss
 }
 
-func FormatStatus(statuses []task.ServiceStatus, vebose, expand bool) string {
+func FormatStatus(statuses []task.ServiceStatus, verbose, expand bool) string {
 	lines := [][]interface{}{}
 
 	// title
@@ -250,7 +250,7 @@ func FormatStatus(statuses []task.ServiceStatus, vebose, expand bool) string {
 
 	// cut column
 	locate := utils.Locate(title)
-	if !vebose {
+	if !verbose {
 		tui.CutColumn(lines, locate["Listen Port"]) // Listen Port
 		tui.CutColumn(lines, locate["Data Dir"])    // Data Dir
 		tui.CutColumn(lines, locate["Log Dir"])     // Log Dir


### PR DESCRIPTION
OSPP Project Number: 222990287

Problem Summary:
Display port number that each service is listening to by default when user uses `curveadm status` command.

### What is changed and how it works?
**internal/tui/service: status.go**
**internal/task/task/common: get_status.go**

#### get_status.go
- added additional step in `NewGetServiceStatusTask` function. New step executes pipeline command inside container to extract port numbers the service is listening to.
- If pipleline command returns any message other than port number(e.g. error message), empty string will be returned as result.

#### status.go
- added new merge function for ports: Duplicated port number will be merged, each port number is splitted by comma.
-  empty string will be return if there is no listening port.
