### PR TITLE
feature(*): support exec subcommand

### DIFF
--- a/cli/command/cmd.go
+++ b/cli/command/cmd.go
@@ -70,6 +70,7 @@ func addSubCommands(cmd *cobra.Command, curveadm *cli.CurveAdm) {
 		NewCompletionCommand(curveadm), // curveadm completion
 		NewDeployCommand(curveadm),     // curveadm deploy
 		NewEnterCommand(curveadm),      // curveadm enter
+		NewExecCommand(curveadm),       // curveadm exec
 		NewFormatCommand(curveadm),     // curveadm format
 		NewMigrateCommand(curveadm),    // curveadm migrate
 		NewPrecheckCommand(curveadm),   // curveadm precheck

--- a/cli/command/exec.go
+++ b/cli/command/exec.go
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: CurveAdm
+ * Created Date: 2021-10-15
+ * Author: Jingli Chen (Wine93)
+ */
+
+// __SIGN_BY_WINE93__
+
+package command
+
+import (
+	"strings"
+
+	"github.com/opencurve/curveadm/cli/cli"
+	"github.com/opencurve/curveadm/internal/configure/topology"
+	"github.com/opencurve/curveadm/internal/errno"
+	"github.com/opencurve/curveadm/internal/tools"
+	"github.com/spf13/cobra"
+)
+
+type execOptions struct {
+	id  string
+	cmd string
+}
+
+func NewExecCommand(curveadm *cli.CurveAdm) *cobra.Command {
+	var options execOptions
+
+	cmd := &cobra.Command{
+		Use:   "exec ID [OPTIONS]",
+		Short: "Exec a cmd in service container",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			options.id = args[0]
+			options.cmd = strings.Join(args[1:], " ")
+			args = args[:1]
+			return curveadm.CheckId(options.id)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runExec(curveadm, options)
+		},
+		DisableFlagsInUseLine: true,
+	}
+
+	return cmd
+}
+
+func runExec(curveadm *cli.CurveAdm, options execOptions) error {
+	// 1) parse cluster topology
+	dcs, err := curveadm.ParseTopology()
+	if err != nil {
+		return err
+	}
+
+	// 2) filter service
+	dcs = curveadm.FilterDeployConfig(dcs, topology.FilterOption{
+		Id:   options.id,
+		Role: "*",
+		Host: "*",
+	})
+	if len(dcs) == 0 {
+		return errno.ERR_NO_SERVICES_MATCHED
+	}
+
+	// 3) get container id
+	dc := dcs[0]
+	serviceId := curveadm.GetServiceId(dc.GetId())
+	containerId, err := curveadm.GetContainerId(serviceId)
+	if err != nil {
+		return err
+	}
+
+	// 4) exec cmd in remote container
+	return tools.ExecCmdInRemoteContainer(curveadm, dc.GetHost(), containerId, options.cmd)
+}

--- a/cli/command/playground/enter.go
+++ b/cli/command/playground/enter.go
@@ -62,6 +62,6 @@ func runEnter(curveadm *cli.CurveAdm, options enterOptions) error {
 			F("id=%s", id)
 	}
 
-	// 2) attch remote container
+	// 2) attch local container
 	return tools.AttachLocalContainer(curveadm, playgrounds[0].Name)
 }


### PR DESCRIPTION
issue #153
usage:
        curveadm exec 0e5d809f16b4 ps
        curveadm exec 0e5d809f16b4 curve_ops_tool status
        curveadm exec 0e5d809f16b4 -- ps -ef

Signed-off-by: Wangpan <aspirer2004@gmail.com>

```
netease@hih-l-9493:~/curveadm$ ./bin/curveadm exec -h
Usage:  curveadm exec ID [OPTIONS]

Exec a cmd in service container

Options:
  -h, --help   Print usage

netease@hih-l-9493:~/curveadm$ ./bin/curveadm exec 0e5d809f16b4 
Connection to 127.0.0.1 closed.
netease@hih-l-9493:~/curveadm$ ./bin/curveadm exec 0e5d809f16b4 -h
Usage:  curveadm exec ID [OPTIONS]

Exec a cmd in service container

Options:
  -h, --help   Print usage

netease@hih-l-9493:~/curveadm$ ./bin/curveadm exec 0e5d809f16b4 ps
    PID TTY          TIME CMD
   1652 pts/3    00:00:00 ps
Connection to 127.0.0.1 closed.

netease@hih-l-9493:~/curveadm$ ./bin/curveadm exec 0e5d809f16b4 "ps -ef"
UID          PID    PPID  C STIME TTY          TIME CMD
root           1       0  0 Nov17 ?        00:00:01 /sbin/docker-init -- /entrypoint.sh --role mds --args=

netease@hih-l-9493:~/curveadm$ ./bin/curveadm exec 0e5d809f16b4 -- ps -ef
UID          PID    PPID  C STIME TTY          TIME CMD
root           1       0  0 Nov17 ?        00:00:01 /sbin/docker-init -- /entrypoint.sh --role mds --args=

netease@hih-l-9493:~/curveadm$ ./bin/curveadm exec 0e5d809f16b4 curve_ops_tool status | head -n3
Cluster status:
Send RPC to chunkserver fail, error content: [E112]Not connected to 127.0.0.1:8200 yet, server_id=6 [R1][E112]Not connected to 127.0.0.1:8200 yet, server_id=6 [R2][E112]Not connected to 127.0.0.1:8200 yet, server_id=6 [R3][E112]Not connected to 127.0.0.1:8200 yet, server_id=6
Send RPC to chunkserver fail, error content: [E112]Not connected to 127.0.0.1:8202 yet, server_id=8 [R1][E112]Not connected to 127.0.0.1:8202 yet, server_id=8 [R2][E112]Not connected to 127.0.0.1:8202 yet, server_id=8 [R3][E112]Not connected to 127.0.0.1:8202 yet, server_id=8
Connection to 127.0.0.1 closed.
netease@hih-l-9493:~/curveadm$ ./bin/curveadm exec 0e5d809f16b4 -- curve_ops_tool status | head -n3
Cluster status:


```