### PR TITLE
[feat] curvebs: The formatting and deployment phases support separate…

### DIFF
--- a/internal/configure/topology/dc_get.go
+++ b/internal/configure/topology/dc_get.go
@@ -42,6 +42,7 @@ const (
 	LAYOUT_SERVICE_CONF_DIR                 = "/conf"
 	LAYOUT_SERVICE_LOG_DIR                  = "/logs"
 	LAYOUT_SERVICE_DATA_DIR                 = "/data"
+	LAYOUT_SERVICE_WAL_DIR                  = "/wal"
 	LAYOUT_TOOLS_DIR                        = "/tools"
 	LAYOUT_TOOLS_V2_DIR                     = "/tools-v2"
 	LAYOUT_CURVEBS_CHUNKFILE_POOL_DIR       = "chunkfilepool"
@@ -131,6 +132,7 @@ func (dc *DeployConfig) GetContainerImage() string {
 }
 func (dc *DeployConfig) GetLogDir() string           { return dc.getString(CONFIG_LOG_DIR) }
 func (dc *DeployConfig) GetDataDir() string          { return dc.getString(CONFIG_DATA_DIR) }
+func (dc *DeployConfig) GetWalDir() string           { return dc.getString(CONFIG_WAL_DIR) }
 func (dc *DeployConfig) GetCoreDir() string          { return dc.getString(CONFIG_CORE_DIR) }
 func (dc *DeployConfig) GetListenIp() string         { return dc.getString(CONFIG_LISTEN_IP) }
 func (dc *DeployConfig) GetListenPort() int          { return dc.getInt(CONFIG_LISTEN_PORT) }
@@ -181,7 +183,8 @@ func (dc *DeployConfig) GetListenExternalPort() int {
  *  │   ├── conf
  *  │   ├── data
  *  │   ├── log
- *  │   └── sbin
+ *  │   ├── sbin
+ *  │   └── wal
  *  ├── snapshotclone
  *  │   ├── conf
  *  │   ├── data
@@ -212,6 +215,7 @@ type (
 		ServiceConfDir     string // /curvebs/mds/conf
 		ServiceLogDir      string // /curvebs/mds/logs
 		ServiceDataDir     string // /curvebs/mds/data
+		ServiceWalDir      string // /curvebs/chunkserver/wal
 		ServiceConfPath    string // /curvebs/mds/conf/mds.conf
 		ServiceConfSrcPath string // /curvebs/conf/mds.conf
 		ServiceConfFiles   []ConfFile
@@ -236,6 +240,9 @@ type (
 		ChunkfilePoolRootDir  string // /curvebs/chunkserver/data
 		ChunkfilePoolDir      string // /curvebs/chunkserver/data/chunkfilepool
 		ChunkfilePoolMetaPath string // /curvebs/chunkserver/data/chunkfilepool.meta
+		WalfilePoolRootDir    string // /curvebs/chunkserver/wal
+		WalfilePoolDir        string // /curvebs/chunkserver/wal/walfilepool
+		WalfilePoolMetaPath   string // /curvebs/chunkserver/wal/walfilepool.meta
 
 		// core
 		CoreSystemDir string
@@ -292,6 +299,7 @@ func (dc *DeployConfig) GetProjectLayout() Layout {
 		ServiceConfDir:     serviceRootDir + LAYOUT_SERVICE_CONF_DIR,
 		ServiceLogDir:      serviceRootDir + LAYOUT_SERVICE_LOG_DIR,
 		ServiceDataDir:     serviceRootDir + LAYOUT_SERVICE_DATA_DIR,
+		ServiceWalDir:      serviceRootDir + LAYOUT_SERVICE_WAL_DIR,
 		ServiceConfPath:    fmt.Sprintf("%s/%s.conf", serviceConfDir, role),
 		ServiceConfSrcPath: fmt.Sprintf("%s/%s.conf", confSrcDir, role),
 		ServiceConfFiles:   serviceConfFiles,

--- a/internal/configure/topology/dc_item.go
+++ b/internal/configure/topology/dc_item.go
@@ -124,6 +124,13 @@ var (
 		nil,
 	)
 
+	CONFIG_WAL_DIR = itemset.insert(
+		"wal_dir",
+		REQUIRE_STRING,
+		true,
+		nil,
+	)
+
 	CONFIG_CORE_DIR = itemset.insert(
 		"core_dir",
 		REQUIRE_STRING,

--- a/internal/errno/errno.go
+++ b/internal/errno/errno.go
@@ -355,6 +355,7 @@ var (
 	ERR_MOUNT_POINT_REQUIRE_ABSOLUTE_PATH        = EC(341002, "mount point must be an absolute path")
 	ERR_FORMAT_PERCENT_REQUIRES_INTERGET         = EC(341003, "format percentage requires an integer")
 	ERR_FORMAT_PERCENT_MUST_BE_BETWEEN_1_AND_100 = EC(341004, "format percentage must be between 1 and 100")
+	ERR_INVALID_FORMAT_TYPE                      = EC(341005, "format type must be (data) or (wal)")
 
 	// 350: configure (client.yaml: parse failed)
 	ERR_PARSE_CLIENT_CONFIGURE_FAILED  = EC(350000, "parse client configure failed")

--- a/internal/task/task/common/create_container.go
+++ b/internal/task/task/common/create_container.go
@@ -106,6 +106,7 @@ func getArguments(dc *topology.DeployConfig) string {
 	// only chunkserver need so many arguments, but who cares
 	layout := dc.GetProjectLayout()
 	dataDir := layout.ServiceDataDir
+	walDir := layout.ServiceWalDir
 	chunkserverArguments := map[string]interface{}{
 		// chunkserver
 		"conf":                  layout.ServiceConfPath,
@@ -115,11 +116,11 @@ func getArguments(dc *topology.DeployConfig) string {
 		"chunkServerPort":       dc.GetListenPort(),
 		"chunkFilePoolDir":      dataDir,
 		"chunkFilePoolMetaPath": fmt.Sprintf("%s/chunkfilepool.meta", dataDir),
-		"walFilePoolDir":        dataDir,
-		"walFilePoolMetaPath":   fmt.Sprintf("%s/walfilepool.meta", dataDir),
+		"walFilePoolDir":        walDir,
+		"walFilePoolMetaPath":   fmt.Sprintf("%s/walfilepool.meta", walDir),
 		"copySetUri":            fmt.Sprintf("local://%s/copysets", dataDir),
 		"recycleUri":            fmt.Sprintf("local://%s/recycler", dataDir),
-		"raftLogUri":            fmt.Sprintf("curve://%s/copysets", dataDir),
+		"raftLogUri":            fmt.Sprintf("curve://%s/copysets", walDir),
 		"raftSnapshotUri":       fmt.Sprintf("curve://%s/copysets", dataDir),
 		"chunkServerStoreUri":   fmt.Sprintf("local://%s", dataDir),
 		"chunkServerMetaUri":    fmt.Sprintf("local://%s/chunkserver.dat", dataDir),
@@ -158,6 +159,7 @@ func getMountVolumes(dc *topology.DeployConfig, serviceMountDevice bool) []step.
 	layout := dc.GetProjectLayout()
 	logDir := dc.GetLogDir()
 	dataDir := dc.GetDataDir()
+	walDir := dc.GetWalDir()
 	coreDir := dc.GetCoreDir()
 
 	if len(logDir) > 0 {
@@ -172,6 +174,13 @@ func getMountVolumes(dc *topology.DeployConfig, serviceMountDevice bool) []step.
 		volumes = append(volumes, step.Volume{
 			HostPath:      dataDir,
 			ContainerPath: layout.ServiceDataDir,
+		})
+	}
+
+	if len(walDir) > 0 {
+		volumes = append(volumes, step.Volume{
+			HostPath:      walDir,
+			ContainerPath: layout.ServiceWalDir,
 		})
 	}
 


### PR DESCRIPTION
… partitioning of WAL and data

change format.yaml，add format_tyep，only can be “wal” or “data”
```
host:
  - machine1
  - machine2
  - machine3
disk:
  - data:/dev/sda:/data/chunkserver0:10  # fortmat_type:device:mount_path:format_percent
  - data:/dev/sdb:/data/chunkserver1:10
  - data:/dev/sdc:/data/chunkserver2:10
  - wal:/dev/nvme0n1p1:/data/wal/chunkserver0:10
  - wal:/dev/nvme0n1p2:/data/wal/chunkserver1:10
  - wal:/dev/nvme0n1p3:/data/wal/chunkserver2:10
```

change topology.yaml，add wal_dir config item
```
chunkserver_services:
  config:
    listen.ip: ${service_host}
    listen.port: 820${service_replicas_sequence}  # 8200,8201,8202
    data_dir: /data/chunkserver${service_replicas_sequence}  # /data/chunkserver0, /data/chunksever1
    wal_dir: /data/wal/chunkserver${service_replicas_sequence}  # /wal/chunkserver0, /wal/chunksever1

```