### PR TITLE
Changed hostname to hostIp to improve visibility 

### DIFF
--- a/cli/cli/cli.go
+++ b/cli/cli/cli.go
@@ -94,11 +94,11 @@ func NewCurveAdm() (*CurveAdm, error) {
 
 	rootDir := fmt.Sprintf("%s/.curveadm", home)
 	curveadm := &CurveAdm{
-		rootDir:   rootDir,
-		dataDir:   path.Join(rootDir, "data"),
-		pluginDir: path.Join(rootDir, "plugins"),
-		logDir:    path.Join(rootDir, "logs"),
-		tempDir:   path.Join(rootDir, "temp"),
+		rootDir:      rootDir,
+		dataDir:      path.Join(rootDir, "data"),
+		pluginDir:    path.Join(rootDir, "plugins"),
+		logDir:       path.Join(rootDir, "logs"),
+		tempDir:      path.Join(rootDir, "temp"),
 		httpConfPath: path.Join(rootDir, "http/conf"),
 		httpLogPath:  path.Join(rootDir, "http/logs"),
 	}
@@ -335,7 +335,7 @@ func (curveadm *CurveAdm) ParseTopologyData(data string) ([]*topology.DeployConf
 		return nil, err
 	}
 	for _, hc := range hcs {
-		ctx.Add(hc.GetHost(), hc.GetHostname())
+		ctx.Add(hc.GetHost(), hc.GetHostIp())
 	}
 
 	dcs, err := topology.ParseTopology(data, ctx)
@@ -499,7 +499,7 @@ func (curveadm *CurveAdm) DiffTopology(data1, data2 string) ([]topology.Topology
 		return nil, err
 	}
 	for _, hc := range hcs {
-		ctx.Add(hc.GetHost(), hc.GetHostname())
+		ctx.Add(hc.GetHost(), hc.GetHostIp())
 	}
 
 	if len(data1) == 0 {

--- a/cli/command/hosts/list_test.go
+++ b/cli/command/hosts/list_test.go
@@ -10,20 +10,20 @@ const (
 	data = `
 hosts:
   - host: host1
-    hostname: 1.1.1.1
+    hostIp: 1.1.1.1
     labels:
       - all
       - host1
       - group1
   - host: host2
-    hostname: 2.2.2.2
+    hostIp: 2.2.2.2
     labels:
       - all
       - host2
       - group1
       - group2
   - host: host3
-    hostname: 3.3.3.3
+    hostIp: 3.3.3.3
     labels:
       - all
       - host3

--- a/internal/configure/hosts/hc_get.go
+++ b/internal/configure/hosts/hc_get.go
@@ -68,7 +68,7 @@ func (hc *HostConfig) getBool(i *comm.Item) bool {
 }
 
 func (hc *HostConfig) GetHost() string           { return hc.getString(CONFIG_HOST) }
-func (hc *HostConfig) GetHostname() string       { return hc.getString(CONFIG_HOSTNAME) }
+func (hc *HostConfig) GetHostIp() string         { return hc.getString(CONFIG_HOSTIP) }
 func (hc *HostConfig) GetSSHHostname() string    { return hc.getString(CONFIG_SSH_HOSTNAME) }
 func (hc *HostConfig) GetUser() string           { return hc.getString(CONFIG_USER) }
 func (hc *HostConfig) GetSSHPort() int           { return hc.getInt(CONFIG_SSH_PORT) }
@@ -80,7 +80,7 @@ func (hc *HostConfig) GetEnvs() []string         { return hc.envs }
 func (hc *HostConfig) GetSSHConfig() *module.SSHConfig {
 	hostname := hc.GetSSHHostname()
 	if len(hostname) == 0 {
-		hostname = hc.GetHostname()
+		hostname = hc.GetHostIp()
 	}
 	return &module.SSHConfig{
 		User:              hc.GetUser(),

--- a/internal/configure/hosts/hc_item.go
+++ b/internal/configure/hosts/hc_item.go
@@ -45,8 +45,8 @@ var (
 		nil,
 	)
 
-	CONFIG_HOSTNAME = itemset.Insert(
-		"hostname",
+	CONFIG_HOSTIP = itemset.Insert(
+		"hostip",
 		comm.REQUIRE_STRING,
 		false,
 		nil,

--- a/internal/configure/hosts/hosts.go
+++ b/internal/configure/hosts/hosts.go
@@ -146,10 +146,10 @@ func (hc *HostConfig) Build() error {
 			F("hosts[%d].host = nil", hc.sequence)
 	} else if len(hc.GetHostIp()) == 0 {
 		return errno.ERR_HOSTNAME_FIELD_MISSING.
-			F("hosts[%d].hostname = nil", hc.sequence)
+			F("hosts[%d].hostIp = nil", hc.sequence)
 	} else if !utils.IsValidAddress(hc.GetHostIp()) {
 		return errno.ERR_HOSTNAME_REQUIRES_VALID_IP_ADDRESS.
-			F("hosts[%d].hostname = %s", hc.sequence, hc.GetHostIp())
+			F("hosts[%d].hostIp = %s", hc.sequence, hc.GetHostIp())
 	} else if hc.GetSSHPort() > os.GetMaxPortNum() {
 		return errno.ERR_HOSTS_SSH_PORT_EXCEED_MAX_PORT_NUMBER.
 			F("hosts[%d].ssh_port = %d", hc.sequence, hc.GetSSHPort())

--- a/internal/configure/hosts/hosts.go
+++ b/internal/configure/hosts/hosts.go
@@ -144,12 +144,12 @@ func (hc *HostConfig) Build() error {
 	if len(hc.GetHost()) == 0 {
 		return errno.ERR_HOST_FIELD_MISSING.
 			F("hosts[%d].host = nil", hc.sequence)
-	} else if len(hc.GetHostname()) == 0 {
+	} else if len(hc.GetHostIp()) == 0 {
 		return errno.ERR_HOSTNAME_FIELD_MISSING.
 			F("hosts[%d].hostname = nil", hc.sequence)
-	} else if !utils.IsValidAddress(hc.GetHostname()) {
+	} else if !utils.IsValidAddress(hc.GetHostIp()) {
 		return errno.ERR_HOSTNAME_REQUIRES_VALID_IP_ADDRESS.
-			F("hosts[%d].hostname = %s", hc.sequence, hc.GetHostname())
+			F("hosts[%d].hostname = %s", hc.sequence, hc.GetHostIp())
 	} else if hc.GetSSHPort() > os.GetMaxPortNum() {
 		return errno.ERR_HOSTS_SSH_PORT_EXCEED_MAX_PORT_NUMBER.
 			F("hosts[%d].ssh_port = %d", hc.sequence, hc.GetSSHPort())

--- a/internal/configure/monitor.go
+++ b/internal/configure/monitor.go
@@ -265,7 +265,7 @@ func ParseMonitorConfig(curveadm *cli.CurveAdm, filename string, data string, hs
 		return nil, err
 	}
 	for _, hc := range hcs {
-		ctx.Add(hc.GetHost(), hc.GetHostname())
+		ctx.Add(hc.GetHost(), hc.GetHostIp())
 	}
 
 	mkind := dcs[0].GetKind()

--- a/internal/configure/topology/context.go
+++ b/internal/configure/topology/context.go
@@ -32,8 +32,8 @@ func NewContext() *Context {
 	return &Context{m: map[string]string{}}
 }
 
-func (ctx *Context) Add(host, hostname string) {
-	ctx.m[host] = hostname
+func (ctx *Context) Add(host, hostIp string) {
+	ctx.m[host] = hostIp
 }
 
 func (ctx *Context) Lookup(host string) string {

--- a/internal/configure/topology/dc.go
+++ b/internal/configure/topology/dc.go
@@ -269,7 +269,7 @@ func (dc *DeployConfig) ResolveHost() error {
 	}
 	dc.hostIp = dc.ctx.Lookup(dc.GetHost())
 	if len(dc.hostIp) == 0 {
-		return errno.ERR_HOST_NOT_FOUND.
+		returtn errno.ERR_HOST_NOT_FOUND.
 			F("host: %s", dc.GetHost())
 	}
 	return nil

--- a/internal/configure/topology/dc.go
+++ b/internal/configure/topology/dc.go
@@ -271,7 +271,6 @@ func (dc *DeployConfig) ResolveHost() error {
 	if len(dc.hostIp) == 0 {
 		return errno.ERR_HOST_NOT_FOUND.
 			F("host: %s", dc.GetHost())
-		F("host: %s", dc.GetHost())
 	}
 	return nil
 }

--- a/internal/configure/topology/dc.go
+++ b/internal/configure/topology/dc.go
@@ -53,7 +53,7 @@ type (
 		parentId         string // role_host_[name/hostSequence]_0
 		role             string // etcd/mds/metaserevr/chunkserver
 		host             string
-		hostname         string
+		hostIp           string
 		name             string
 		replicas         int
 		hostSequence     int // start with 0
@@ -251,7 +251,7 @@ func (dc *DeployConfig) convert() error {
 
 func (dc *DeployConfig) ResolveHost() error {
 	if dc.ctx == nil {
-		dc.hostname = dc.host
+		dc.hostIp = dc.host
 		return nil
 	}
 
@@ -267,10 +267,11 @@ func (dc *DeployConfig) ResolveHost() error {
 	if err != nil {
 		return errno.ERR_RENDERING_VARIABLE_FAILED.E(err)
 	}
-	dc.hostname = dc.ctx.Lookup(dc.GetHost())
-	if len(dc.hostname) == 0 {
+	dc.hostIp = dc.ctx.Lookup(dc.GetHost())
+	if len(dc.hostIp) == 0 {
 		return errno.ERR_HOST_NOT_FOUND.
 			F("host: %s", dc.GetHost())
+		F("host: %s", dc.GetHost())
 	}
 	return nil
 }

--- a/internal/configure/topology/dc.go
+++ b/internal/configure/topology/dc.go
@@ -269,7 +269,7 @@ func (dc *DeployConfig) ResolveHost() error {
 	}
 	dc.hostIp = dc.ctx.Lookup(dc.GetHost())
 	if len(dc.hostIp) == 0 {
-		returtn errno.ERR_HOST_NOT_FOUND.
+		return errno.ERR_HOST_NOT_FOUND.
 			F("host: %s", dc.GetHost())
 	}
 	return nil

--- a/internal/configure/topology/dc_get.go
+++ b/internal/configure/topology/dc_get.go
@@ -115,7 +115,7 @@ func (dc *DeployConfig) GetId() string                       { return dc.id }
 func (dc *DeployConfig) GetParentId() string                 { return dc.parentId }
 func (dc *DeployConfig) GetRole() string                     { return dc.role }
 func (dc *DeployConfig) GetHost() string                     { return dc.host }
-func (dc *DeployConfig) GetHostname() string                 { return dc.hostname }
+func (dc *DeployConfig) GetHostIp() string                   { return dc.hostIp }
 func (dc *DeployConfig) GetName() string                     { return dc.name }
 func (dc *DeployConfig) GetReplicas() int                    { return dc.replicas }
 func (dc *DeployConfig) GetHostSequence() int                { return dc.hostSequence }

--- a/internal/configure/topology/dc_item.go
+++ b/internal/configure/topology/dc_item.go
@@ -136,7 +136,7 @@ var (
 		REQUIRE_STRING,
 		true,
 		func(dc *DeployConfig) interface{} {
-			return dc.GetHostname()
+			return dc.GetHostIp()
 		},
 	)
 
@@ -195,7 +195,7 @@ var (
 		REQUIRE_STRING,
 		true,
 		func(dc *DeployConfig) interface{} {
-			return dc.GetHostname()
+			return dc.GetHostIp()
 		},
 	)
 

--- a/internal/configure/topology/variables.go
+++ b/internal/configure/topology/variables.go
@@ -241,7 +241,7 @@ func getValue(name string, dcs []*DeployConfig, idx int) string {
 	case "service_role":
 		return dc.GetRole()
 	case "service_host":
-		return dc.GetHostname()
+		return dc.GetHostIp()
 	case "service_host_sequence":
 		return strconv.Itoa(dc.GetHostSequence())
 	case "service_replica_sequence":

--- a/internal/errno/errno.go
+++ b/internal/errno/errno.go
@@ -302,13 +302,13 @@ var (
 	// 321: configure (hosts.yaml: invalid configure value)
 	ERR_UNSUPPORT_HOSTS_CONFIGURE_ITEM           = EC(321000, "unsupport hosts configure item")
 	ERR_HOST_FIELD_MISSING                       = EC(321001, "host field missing")
-	ERR_HOSTNAME_FIELD_MISSING                   = EC(321002, "hostname field missing")
+	ERR_HOSTNAME_FIELD_MISSING                   = EC(321002, "hostIp field missing")
 	ERR_HOSTS_SSH_PORT_EXCEED_MAX_PORT_NUMBER    = EC(321003, "ssh_port exceed max port number")
 	ERR_PRIVATE_KEY_FILE_REQUIRE_ABSOLUTE_PATH   = EC(321004, "SSH private key file needs to be an absolute path")
 	ERR_PRIVATE_KEY_FILE_NOT_EXIST               = EC(321005, "SSH private key file not exist")
 	ERR_PRIVATE_KEY_FILE_REQUIRE_600_PERMISSIONS = EC(321006, "SSH private key file require 600 permissions")
 	ERR_DUPLICATE_HOST                           = EC(321007, "host is duplicate")
-	ERR_HOSTNAME_REQUIRES_VALID_IP_ADDRESS       = EC(321008, "hostname requires valid IP address")
+	ERR_HOSTNAME_REQUIRES_VALID_IP_ADDRESS       = EC(321008, "hostIp requires valid IP address")
 
 	// 322: configure (disks.yaml: parse failed)
 	ERR_DISKS_FILE_NOT_FOUND   = EC(322000, "disks file not found")
@@ -470,7 +470,7 @@ var (
 
 	// 520: checker (permission)
 	ERR_USER_NOT_FOUND                           = EC(520000, "user not found")
-	ERR_HOSTNAME_NOT_RESOLVED                    = EC(520001, "hostname not resolved")
+	ERR_HOSTNAME_NOT_RESOLVED                    = EC(520001, "hostIp not resolved")
 	ERR_CREATE_DIRECOTRY_PERMISSION_DENIED       = EC(520002, "create direcotry permission denied")
 	ERR_EXECUTE_DOCKER_COMMAND_PERMISSION_DENIED = EC(520003, "execute docker command permission denied")
 
@@ -538,7 +538,7 @@ var (
 	ERR_GET_SYSTEM_INFORMATION_FAILED              = EC(620019, "get system information failed (uname)")
 	ERR_GET_KERNEL_MODULE_INFO_FAILED              = EC(620020, "get kernel module information failed (modinfo)")
 	ERR_ADD_MODUDLE_FROM_LINUX_KERNEL_FAILED       = EC(620021, "add module from linux kernel failed (modprobe)")
-	ERR_GET_HOSTNAME_FAILED                        = EC(620022, "get hostname failed (hostname)")
+	ERR_GET_HOSTNAME_FAILED                        = EC(620022, "get hostIp failed (hostIp)")
 	ERR_STORES_AND_EXTRACTS_FILES_FAILED           = EC(620023, "stores and extracts files failed (tar)")
 	ERR_INSTALL_OR_REMOVE_DEBIAN_PACKAGE_FAILED    = EC(620024, "install or remove debian package failed (dpkg)")
 	ERR_INSTALL_OR_REMOVE_RPM_PACKAGE_FAILED       = EC(620025, "install or remove rpm package failed (rpm)")

--- a/internal/task/task/bs/create_volume.go
+++ b/internal/task/task/bs/create_volume.go
@@ -73,7 +73,7 @@ func NewCreateVolumeTask(curveadm *cli.CurveAdm, cc *configure.ClientConfig) (*t
 		return nil, err
 	}
 
-	subname := fmt.Sprintf("hostname=%s image=%s", hc.GetHostname(), cc.GetContainerImage())
+	subname := fmt.Sprintf("hostip=%s image=%s", hc.GetHostIp(), cc.GetContainerImage())
 	t := task.NewTask("Create Volume", subname, hc.GetSSHConfig())
 
 	// add step

--- a/internal/task/task/bs/delete_target.go
+++ b/internal/task/task/bs/delete_target.go
@@ -57,7 +57,7 @@ func NewDeleteTargetTask(curveadm *cli.CurveAdm, cc *client.ClientConfig) (*task
 		return nil, err
 	}
 
-	subname := fmt.Sprintf("hostname=%s tid=%s", hc.GetHostname(), options.Tid)
+	subname := fmt.Sprintf("hostip=%s tid=%s", hc.GetHostIp(), options.Tid)
 	t := task.NewTask("Delete Target", subname, hc.GetSSHConfig())
 
 	// add step
@@ -83,7 +83,7 @@ func NewDeleteTargetTask(curveadm *cli.CurveAdm, cc *client.ClientConfig) (*task
 	})
 	t.AddStep(&step2FormatTarget{
 		host:       options.Host,
-		hostname:   hc.GetHostname(),
+		hostIp:     hc.GetHostIp(),
 		output:     &output,
 		memStorage: curveadm.MemStorage(),
 	})

--- a/internal/task/task/bs/list_targets.go
+++ b/internal/task/task/bs/list_targets.go
@@ -42,7 +42,7 @@ const (
 type (
 	step2FormatTarget struct {
 		host       string
-		hostname   string
+		hostIp     string
 		output     *string
 		memStorage *utils.SafeMap
 	}
@@ -88,7 +88,7 @@ func (s *step2FormatTarget) Execute(ctx *context.Context) error {
 				Tid:    mu[1],
 				Name:   mu[2],
 				Store:  "-",
-				Portal: fmt.Sprintf("%s:%d", s.hostname, DEFAULT_TGTD_LISTEN_PORT),
+				Portal: fmt.Sprintf("%s:%d", s.hostIp, DEFAULT_TGTD_LISTEN_PORT),
 			}
 			addTarget(s.memStorage, mu[1], target)
 			continue
@@ -110,7 +110,7 @@ func NewListTargetsTask(curveadm *cli.CurveAdm, v interface{}) (*task.Task, erro
 		return nil, err
 	}
 
-	subname := fmt.Sprintf("host=%s", hc.GetHostname())
+	subname := fmt.Sprintf("host=%s", hc.GetHostIp())
 	t := task.NewTask("List Targets", subname, hc.GetSSHConfig())
 
 	// add step
@@ -136,7 +136,7 @@ func NewListTargetsTask(curveadm *cli.CurveAdm, v interface{}) (*task.Task, erro
 	})
 	t.AddStep(&step2FormatTarget{
 		host:       options.Host,
-		hostname:   hc.GetHostname(),
+		hostIp:     hc.GetHostIp(),
 		output:     &output,
 		memStorage: curveadm.MemStorage(),
 	})

--- a/internal/task/task/bs/map.go
+++ b/internal/task/task/bs/map.go
@@ -78,7 +78,7 @@ func NewMapTask(curveadm *cli.CurveAdm, cc *configure.ClientConfig) (*task.Task,
 		return nil, err
 	}
 
-	subname := fmt.Sprintf("hostname=%s volume=%s:%s", hc.GetHostname(), options.User, options.Volume)
+	subname := fmt.Sprintf("hostip=%s volume=%s:%s", hc.GetHostIp(), options.User, options.Volume)
 	t := task.NewTask("Map Volume", subname, hc.GetSSHConfig())
 
 	// add step

--- a/internal/task/task/bs/start_nebd.go
+++ b/internal/task/task/bs/start_nebd.go
@@ -145,7 +145,7 @@ func NewStartNEBDServiceTask(curveadm *cli.CurveAdm, cc *configure.ClientConfig)
 		return nil, err
 	}
 
-	subname := fmt.Sprintf("hostname=%s image=%s", hc.GetHostname(), cc.GetContainerImage())
+	subname := fmt.Sprintf("hostip=%s image=%s", hc.GetHostIp(), cc.GetContainerImage())
 	t := task.NewTask("Start NEBD Service", subname, hc.GetSSHConfig())
 
 	// add step
@@ -154,7 +154,7 @@ func NewStartNEBDServiceTask(curveadm *cli.CurveAdm, cc *configure.ClientConfig)
 	volume := fmt.Sprintf("%s:%s", options.User, options.Volume)
 	containerName := volume2ContainerName(options.User, options.Volume)
 	hostname := containerName
-	host2addr := fmt.Sprintf("%s:%s", hostname, hc.GetHostname())
+	host2addr := fmt.Sprintf("%s:%s", hostname, hc.GetHostIp())
 
 	t.AddStep(&step.DockerInfo{
 		Success:     &success,

--- a/internal/task/task/bs/start_tgtd.go
+++ b/internal/task/task/bs/start_tgtd.go
@@ -72,7 +72,7 @@ func NewStartTargetDaemonTask(curveadm *cli.CurveAdm, cc *configure.ClientConfig
 	var status, containerId, out string
 	containerName := DEFAULT_TGTD_CONTAINER_NAME
 	hostname := containerName
-	host2addr := fmt.Sprintf("%s:%s", hostname, hc.GetHostname())
+	host2addr := fmt.Sprintf("%s:%s", hostname, hc.GetHostIp())
 
 	t.AddStep(&step.ListContainers{
 		ShowAll:     true,

--- a/internal/task/task/bs/unmap.go
+++ b/internal/task/task/bs/unmap.go
@@ -136,8 +136,8 @@ func NewUnmapTask(curveadm *cli.CurveAdm, v interface{}) (*task.Task, error) {
 		return nil, err
 	}
 
-	subname := fmt.Sprintf("hostname=%s volume=%s:%s containerId=%s",
-		hc.GetHostname(), options.User, options.Volume, tui.TrimContainerId(containerId))
+	subname := fmt.Sprintf("hostip=%s volume=%s:%s containerId=%s",
+		hc.GetHostIp(), options.User, options.Volume, tui.TrimContainerId(containerId))
 	t := task.NewTask("Unmap Volume", subname, hc.GetSSHConfig())
 
 	// add step

--- a/internal/tui/hosts.go
+++ b/internal/tui/hosts.go
@@ -42,8 +42,7 @@ func FormatHosts(hcs []*configure.HostConfig, verbose bool) string {
 	lines := [][]interface{}{}
 	title := []string{
 		"Host",
-		"Hostip" +
-			"",
+		"Hostip",
 		"User",
 		"Port",
 		"Private Key File",
@@ -76,7 +75,7 @@ func FormatHosts(hcs []*configure.HostConfig, verbose bool) string {
 
 		lines = append(lines, []interface{}{
 			host,
-			hostip,
+			hostIp,
 			user,
 			port,
 			privateKeyFile,

--- a/internal/tui/hosts.go
+++ b/internal/tui/hosts.go
@@ -42,7 +42,8 @@ func FormatHosts(hcs []*configure.HostConfig, verbose bool) string {
 	lines := [][]interface{}{}
 	title := []string{
 		"Host",
-		"Hostname",
+		"Hostip" +
+			"",
 		"User",
 		"Port",
 		"Private Key File",
@@ -59,7 +60,7 @@ func FormatHosts(hcs []*configure.HostConfig, verbose bool) string {
 		hc := hcs[i]
 
 		host := hc.GetHost()
-		hostname := hc.GetHostname()
+		hostIp := hc.GetHostIp()
 		user := hc.GetUser()
 		port := strconv.Itoa(hc.GetSSHPort())
 		forwardAgent := utils.Choose(hc.GetForwardAgent(), "Y", "N")
@@ -75,7 +76,7 @@ func FormatHosts(hcs []*configure.HostConfig, verbose bool) string {
 
 		lines = append(lines, []interface{}{
 			host,
-			hostname,
+			hostip,
 			user,
 			port,
 			privateKeyFile,

--- a/playbook/automount/hosts.yaml
+++ b/playbook/automount/hosts.yaml
@@ -5,14 +5,14 @@ global:
 
 hosts:
   - host: server-host1
-    hostname: 10.0.1.1
+    hostIp: 10.0.1.1
     labels:
       - automount
     envs:
       - SUDO_ALIAS=sudo
       - OPTIONS=""
   - host: server-host2
-    hostname: 10.0.1.2
+    hostIp: 10.0.1.2
     labels:
       - automount
     envs:

--- a/playbook/memcached/hosts.yaml
+++ b/playbook/memcached/hosts.yaml
@@ -5,7 +5,7 @@ global:
 
 hosts:
   - host: server-host1
-    hostname: 10.0.1.1
+    hostIp: 10.0.1.1
     labels:
       - memcached
     envs:
@@ -23,7 +23,7 @@ hosts:
                     # vv:  very verbose (also print client commands/responses)
                     # vvv: extremely verbose (internal state transitions)
   - host: server-host2
-    hostname: 10.0.1.2
+    hostIp: 10.0.1.2
     labels:
       - memcached
     envs:
@@ -41,7 +41,7 @@ hosts:
                     # vv:  very verbose (also print client commands/responses)
                     # vvv: extremely verbose (internal state transitions)
   - host: server-host3
-    hostname: 10.0.1.3
+    hostIp: 10.0.1.3
     labels:
       - memcached
     envs:


### PR DESCRIPTION
The hold hostname might confuse user from knowing its true usage: ip of host. By changing it to hostIp and get methods accordingly, this will make opencurveadm easier for user to operate on. 