### PR TITLE
fix: The "quiet" and "format" options of the "docker ps" command cann…

### DIFF
--- a/internal/task/step/container.go
+++ b/internal/task/step/container.go
@@ -280,13 +280,14 @@ func (s *ListContainers) Execute(ctx *context.Context) error {
 	cli := ctx.Module().DockerCli().ListContainers()
 	if len(s.Format) > 0 {
 		cli.AddOption("--format %s", s.Format)
+	} else if s.Quiet {
+		cli.AddOption("--quiet")
 	}
+
 	if len(s.Filter) > 0 {
 		cli.AddOption("--filter %s", s.Filter)
 	}
-	if s.Quiet {
-		cli.AddOption("--quiet")
-	}
+
 	if s.ShowAll {
 		cli.AddOption("--all")
 	}


### PR DESCRIPTION
…ot be used simultaneously.

docker version=24.0.5, Using both the "quiet" and "format" options with the "docker ps" command will result in the following warning message being output:
```
docker ps --quiet --all --format {{.ID}}
WARNING: Ignoring custom format, because both --format and --quiet are set.
6c227a4634ed
13c9655df5ab
bc0e9b0cfeb2
750ea4be0ee1
```

This will lead to an error when executing the "curveadm client map" command, as the aforementioned warning output could be mistaken for the volume container already being installed. However, in reality, the "docker ps" command output list is empty.

Error-Code: 420000
Error-Description: volume already mapped
Error-Clue: volume: work:/abc
