### PR TITLE
[fix] add support for recognizing kernel versions like "3.15.0_.*"

### DIFF
--- a/internal/task/task/checker/kernel.go
+++ b/internal/task/task/checker/kernel.go
@@ -42,7 +42,7 @@ import (
 
 const (
 	CHUNKSERVER_LEAST_KERNEL_VERSION = "3.15.0"
-	REGEX_KERNEL_VAERSION            = "^(\\d+\\.\\d+\\.\\d+)(-.+)?$"
+	REGEX_KERNEL_VAERSION            = "^(\\d+\\.\\d+\\.\\d+)(?:[-_].+)?$"
 )
 
 func calcKernelVersion(version string) int {

--- a/internal/task/task/checker/kernel_test.go
+++ b/internal/task/task/checker/kernel_test.go
@@ -39,6 +39,7 @@ func TestCheckKernelVersion(t *testing.T) {
 	}{
 		{"5.12.0", nil},
 		{"4.9.65-netease", nil},
+		{"4.18.0_80.7.1.el8_0_bch_v1.0", nil},
 		{"4.19.0-16-amd64", nil},
 		{"3.15.0", nil},
 		{"3.15.0.0.", errno.ERR_UNRECOGNIZED_KERNEL_VERSION},


### PR DESCRIPTION
Fixed: #225

Have passed `make test`.