### PR TITLE
[fix]getClusterPool: performing a type conversion on a nil.

### DIFF
--- a/cli/command/deploy.go
+++ b/cli/command/deploy.go
@@ -243,6 +243,8 @@ func genDeployPlaybook(curveadm *cli.CurveAdm,
 			options[comm.POOLSET_DISK_TYPE] = diskType
 		} else if step == CREATE_LOGICAL_POOL {
 			options[comm.KEY_CREATE_POOL_TYPE] = comm.POOL_TYPE_LOGICAL
+			options[comm.POOLSET] = poolset
+			options[comm.POOLSET_DISK_TYPE] = diskType
 		}
 
 		pb.AddStep(&playbook.PlaybookStep{

--- a/cli/command/deploy.go
+++ b/cli/command/deploy.go
@@ -243,8 +243,6 @@ func genDeployPlaybook(curveadm *cli.CurveAdm,
 			options[comm.POOLSET_DISK_TYPE] = diskType
 		} else if step == CREATE_LOGICAL_POOL {
 			options[comm.KEY_CREATE_POOL_TYPE] = comm.POOL_TYPE_LOGICAL
-			options[comm.POOLSET] = poolset
-			options[comm.POOLSET_DISK_TYPE] = diskType
 		}
 
 		pb.AddStep(&playbook.PlaybookStep{

--- a/cli/command/migrate.go
+++ b/cli/command/migrate.go
@@ -103,7 +103,7 @@ var (
 )
 
 type migrateOptions struct {
-	filename string
+	filename        string
 	poolset         string
 	poolsetDiskType string
 }
@@ -184,7 +184,7 @@ func getMigrates(curveadm *cli.CurveAdm, data string) []*configure.MigrateServer
 }
 
 func genMigratePlaybook(curveadm *cli.CurveAdm,
-	dcs []*topology.DeployConfig, options migrateOptions,data string) (*playbook.Playbook, error) {
+	dcs []*topology.DeployConfig, options migrateOptions, data string) (*playbook.Playbook, error) {
 	diffs, _ := diffTopology(curveadm, data)
 	dcs2add := diffs[topology.DIFF_ADD]
 	dcs2del := diffs[topology.DIFF_DELETE]
@@ -224,8 +224,6 @@ func genMigratePlaybook(curveadm *cli.CurveAdm,
 			options[comm.KEY_CREATE_POOL_TYPE] = comm.POOL_TYPE_LOGICAL
 			options[comm.KEY_MIGRATE_SERVERS] = migrates
 			options[comm.KEY_NEW_TOPOLOGY_DATA] = data
-			options[comm.POOLSET] = poolset
-			options[comm.POOLSET_DISK_TYPE] = poolsetDiskType
 		case playbook.UPDATE_TOPOLOGY:
 			options[comm.KEY_NEW_TOPOLOGY_DATA] = data
 		}


### PR DESCRIPTION
related: [#308 ](https://github.com/opencurve/curveadm/issues/308)
fix curveadm is performing a type conversion on a nil. 
Solution: Add poolset and diskType to the option choices. So, there won't be a nil. 
