### PR TITLE
Improve(hosts): use more meaningful name for host name

### DIFF
--- a/cli/cli/cli.go
+++ b/cli/cli/cli.go
@@ -278,10 +278,10 @@ func (curveadm *CurveAdm) ClusterTopologyData() string       { return curveadm.c
 func (curveadm *CurveAdm) ClusterPoolData() string           { return curveadm.clusterPoolData }
 func (curveadm *CurveAdm) Monitor() storage.Monitor          { return curveadm.monitor }
 
-func (curveadm *CurveAdm) GetHost(host string) (*hosts.HostConfig, error) {
+func (curveadm *CurveAdm) GetHost(name string) (*hosts.HostConfig, error) {
 	if len(curveadm.Hosts()) == 0 {
 		return nil, errno.ERR_HOST_NOT_FOUND.
-			F("host: %s", host)
+			F("host: %s", name)
 	}
 	hcs, err := hosts.ParseHosts(curveadm.Hosts())
 	if err != nil {
@@ -289,12 +289,12 @@ func (curveadm *CurveAdm) GetHost(host string) (*hosts.HostConfig, error) {
 	}
 
 	for _, hc := range hcs {
-		if hc.GetHost() == host {
+		if hc.GetName() == name {
 			return hc, nil
 		}
 	}
 	return nil, errno.ERR_HOST_NOT_FOUND.
-		F("host: %s", host)
+		F("host: %s", name)
 }
 
 func (curveadm *CurveAdm) ParseTopologyData(data string) ([]*topology.DeployConfig, error) {
@@ -304,7 +304,7 @@ func (curveadm *CurveAdm) ParseTopologyData(data string) ([]*topology.DeployConf
 		return nil, err
 	}
 	for _, hc := range hcs {
-		ctx.Add(hc.GetHost(), hc.GetHostname())
+		ctx.Add(hc.GetName(), hc.GetHostname())
 	}
 
 	dcs, err := topology.ParseTopology(data, ctx)
@@ -464,7 +464,7 @@ func (curveadm *CurveAdm) DiffTopology(data1, data2 string) ([]topology.Topology
 		return nil, err
 	}
 	for _, hc := range hcs {
-		ctx.Add(hc.GetHost(), hc.GetHostname())
+		ctx.Add(hc.GetName(), hc.GetHostname())
 	}
 
 	if len(data1) == 0 {

--- a/cli/command/hosts/list_test.go
+++ b/cli/command/hosts/list_test.go
@@ -37,7 +37,7 @@ func run(t *testing.T, data string, labels []string, out []string) {
 	assert.Nil(err)
 	assert.Equal(len(hcs), len(out))
 	for i, hc := range hcs {
-		assert.Equal(hc.GetHost(), out[i])
+		assert.Equal(hc.GetName(), out[i])
 	}
 }
 

--- a/cli/command/hosts/playbook.go
+++ b/cli/command/hosts/playbook.go
@@ -91,7 +91,7 @@ func NewPlaybookCommand(curveadm *cli.CurveAdm) *cobra.Command {
 
 func execute(curveadm *cli.CurveAdm, options playbookOptions, idx int, hc *hosts.HostConfig) {
 	defer func() { wg.Done() }()
-	name := hc.GetHost()
+	name := hc.GetName()
 	target := path.Join("/tmp", utils.RandString(8))
 	err := tools.Scp(curveadm, name, options.filepath, target)
 	if err != nil {

--- a/internal/configure/hosts/hc_get.go
+++ b/internal/configure/hosts/hc_get.go
@@ -67,7 +67,17 @@ func (hc *HostConfig) getBool(i *comm.Item) bool {
 	return v.(bool)
 }
 
+func (hc *HostConfig) getName() string {
+	res := hc.GetHost()
+	if res != "" {
+		return res
+	}
+
+	return hc.getString(CONFIG_NAME)
+}
+
 func (hc *HostConfig) GetHost() string           { return hc.getString(CONFIG_HOST) }
+func (hc *HostConfig) GetName() string           { return hc.getName() }
 func (hc *HostConfig) GetHostname() string       { return hc.getString(CONFIG_HOSTNAME) }
 func (hc *HostConfig) GetSSHHostname() string    { return hc.getString(CONFIG_SSH_HOSTNAME) }
 func (hc *HostConfig) GetSSHPort() int           { return hc.getInt(CONFIG_SSH_PORT) }

--- a/internal/configure/hosts/hc_get.go
+++ b/internal/configure/hosts/hc_get.go
@@ -67,17 +67,7 @@ func (hc *HostConfig) getBool(i *comm.Item) bool {
 	return v.(bool)
 }
 
-func (hc *HostConfig) getName() string {
-	res := hc.GetHost()
-	if res != "" {
-		return res
-	}
-
-	return hc.getString(CONFIG_NAME)
-}
-
-func (hc *HostConfig) GetHost() string           { return hc.getString(CONFIG_HOST) }
-func (hc *HostConfig) GetName() string           { return hc.getName() }
+func (hc *HostConfig) GetName() string           { return hc.getString(CONFIG_NAME) }
 func (hc *HostConfig) GetHostname() string       { return hc.getString(CONFIG_HOSTNAME) }
 func (hc *HostConfig) GetSSHHostname() string    { return hc.getString(CONFIG_SSH_HOSTNAME) }
 func (hc *HostConfig) GetSSHPort() int           { return hc.getInt(CONFIG_SSH_PORT) }

--- a/internal/configure/hosts/hc_item.go
+++ b/internal/configure/hosts/hc_item.go
@@ -45,6 +45,12 @@ var (
 		nil,
 	)
 
+	CONFIG_NAME = itemset.Insert(
+		"name",
+		comm.REQUIRE_STRING,
+		false,
+		nil,
+	)
 	CONFIG_HOSTNAME = itemset.Insert(
 		"hostname",
 		comm.REQUIRE_STRING,

--- a/internal/configure/hosts/hc_item.go
+++ b/internal/configure/hosts/hc_item.go
@@ -49,8 +49,11 @@ var (
 		"name",
 		comm.REQUIRE_STRING,
 		false,
-		nil,
+		func(hc *HostConfig) interface{} {
+			return hc.getString(CONFIG_HOST)
+		},
 	)
+
 	CONFIG_HOSTNAME = itemset.Insert(
 		"hostname",
 		comm.REQUIRE_STRING,

--- a/internal/configure/hosts/hosts.go
+++ b/internal/configure/hosts/hosts.go
@@ -141,9 +141,9 @@ func (hc *HostConfig) Build() error {
 	}
 
 	privateKeyFile := hc.GetPrivateKeyFile()
-	if len(hc.GetHost()) == 0 {
+	if len(hc.GetName()) == 0 {
 		return errno.ERR_HOST_FIELD_MISSING.
-			F("hosts[%d].host = nil", hc.sequence)
+			F("hosts[%d].host/name = nil", hc.sequence)
 	} else if len(hc.GetHostname()) == 0 {
 		return errno.ERR_HOSTNAME_FIELD_MISSING.
 			F("hosts[%d].hostname = nil", hc.sequence)
@@ -206,12 +206,12 @@ func ParseHosts(data string) ([]*HostConfig, error) {
 			return nil, err
 		}
 
-		if _, ok := exist[hc.GetHost()]; ok {
-			return nil, errno.ERR_DUPLICATE_HOST.
-				F("duplicate host: %s", hc.GetHost())
+		if _, ok := exist[hc.GetName()]; ok {
+			return nil, errno.ERR_DUPLICATE_NAME.
+				F("duplicate host: %s", hc.GetName())
 		}
 		hcs = append(hcs, hc)
-		exist[hc.GetHost()] = true
+		exist[hc.GetName()] = true
 	}
 	build.DEBUG(build.DEBUG_HOSTS, hosts)
 	return hcs, nil

--- a/internal/configure/monitor.go
+++ b/internal/configure/monitor.go
@@ -265,7 +265,7 @@ func ParseMonitorConfig(curveadm *cli.CurveAdm, filename string, data string, hs
 		return nil, err
 	}
 	for _, hc := range hcs {
-		ctx.Add(hc.GetHost(), hc.GetHostname())
+		ctx.Add(hc.GetName(), hc.GetHostname())
 	}
 
 	mkind := dcs[0].GetKind()

--- a/internal/errno/errno.go
+++ b/internal/errno/errno.go
@@ -310,7 +310,7 @@ var (
 	ERR_PRIVATE_KEY_FILE_REQUIRE_ABSOLUTE_PATH   = EC(321004, "SSH private key file needs to be an absolute path")
 	ERR_PRIVATE_KEY_FILE_NOT_EXIST               = EC(321005, "SSH private key file not exist")
 	ERR_PRIVATE_KEY_FILE_REQUIRE_600_PERMISSIONS = EC(321006, "SSH private key file require 600 permissions")
-	ERR_DUPLICATE_HOST                           = EC(321007, "host is duplicate")
+	ERR_DUPLICATE_NAME                           = EC(321007, "name is duplicate")
 	ERR_HOSTNAME_REQUIRES_VALID_IP_ADDRESS       = EC(321008, "hostname requires valid IP address")
 
 	// 322: configure (monitor.yaml: parse failed)

--- a/internal/task/task/common/client_status.go
+++ b/internal/task/task/common/client_status.go
@@ -163,7 +163,7 @@ func NewGetClientStatusTask(curveadm *cli.CurveAdm, v interface{}) (*task.Task, 
 
 	containerId := client.ContainerId
 	subname := fmt.Sprintf("host=%s kind=%s containerId=%s",
-		hc.GetHost(), client.Kind, tui.TrimContainerId(containerId))
+		hc.GetName(), client.Kind, tui.TrimContainerId(containerId))
 	t := task.NewTask("Get Client Status", subname, hc.GetSSHConfig())
 
 	// add step

--- a/internal/task/task/common/collect_client.go
+++ b/internal/task/task/common/collect_client.go
@@ -46,7 +46,7 @@ func NewCollectClientTask(curveadm *cli.CurveAdm, v interface{}) (*task.Task, er
 	// new task
 	containerId := client.ContainerId
 	subname := fmt.Sprintf("host=%s kind=%s containerId=%s",
-		hc.GetHost(), client.Kind, tui.TrimContainerId(containerId))
+		hc.GetName(), client.Kind, tui.TrimContainerId(containerId))
 	t := task.NewTask("Collect Client", subname, hc.GetSSHConfig())
 
 	// add step to task

--- a/internal/tui/hosts.go
+++ b/internal/tui/hosts.go
@@ -41,7 +41,7 @@ const (
 func FormatHosts(hcs []*configure.HostConfig, verbose bool) string {
 	lines := [][]interface{}{}
 	title := []string{
-		"Host",
+		"Name",
 		"Hostname",
 		"User",
 		"Port",
@@ -58,7 +58,7 @@ func FormatHosts(hcs []*configure.HostConfig, verbose bool) string {
 	for i := 0; i < len(hcs); i++ {
 		hc := hcs[i]
 
-		host := hc.GetHost()
+		name := hc.GetName()
 		hostname := hc.GetHostname()
 		user := hc.GetUser()
 		port := strconv.Itoa(hc.GetSSHPort())
@@ -74,7 +74,7 @@ func FormatHosts(hcs []*configure.HostConfig, verbose bool) string {
 		}
 
 		lines = append(lines, []interface{}{
-			host,
+			name,
 			hostname,
 			user,
 			port,


### PR DESCRIPTION
This PR is about issue #260. I followed the advice of the instructor in the last PR and changed the host (keyword used to express the host identifier) in the configuration file required by curveadm hosts to name, and retained it. hostname keyword

Tests I did:
1. Under the curveadm hosts command, this keyword can work normally, and all commands under hosts can work normally.
2. Under curveadm format, the disk can be formatted normally.
3. The entire process of deploying curvefs can be carried out normally.

The tests I have done may still be incomplete. I hope to get the code review from the instructor and give further suggestions for modifications.

这个pr是有关于issue #260的,我遵循了上一次pr中导师提出的意见,将curveadm hosts 所需的配置文件中的host(用来表达主机标识符的关键字)更改为了name,并保留了hostname关键字

我所做的测试:
1.curveadm hosts命令下,该关键字可以正常发挥效果,hosts下的所有指令均能正常工作
2.curveadm format下,可以正常对磁盘进行格式化
3.可以正常进行整套部署curvefs的流程

我所做的测试可能仍不完备,希望能得到导师的代码审查,并给出更进一步的修改意见

