### PR TITLE
fix: config commit --force not work

### DIFF
--- a/cli/command/config/commit.go
+++ b/cli/command/config/commit.go
@@ -184,7 +184,7 @@ func checkTopology(curveadm *cli.CurveAdm, data string, options commitOptions) e
 func runCommit(curveadm *cli.CurveAdm, options commitOptions) error {
 	// 1) parse cluster topology
 	_, err := curveadm.ParseTopology()
-	if err != nil && !skipError(err) {
+	if err != nil && !skipError(err) && !options.force {
 		return err
 	}
 


### PR DESCRIPTION
In the following code snippet, when curveadm.ParseTopology() function returns an error, it will return err.
but  if --force=1 option is set, the logic to update the config should continue to execute.
```
func runCommit(curveadm *cli.CurveAdm, options commitOptions) error {
	// 1) parse cluster topology
	_, err := curveadm.ParseTopology()
	if err != nil && !skipError(err) {
		return err
	}
}
```



Case:
(1) For example, for the following config, it has syntax errors(a=1), but the config update will still succeed.
(2) But now if you try to update the config(a: 1), it will fail, reporting a parsing error and unable to proceed the update.
```
chunkserver_services:
  config:
      a=1
```