### PR TITLE
playbook memcached add instances and ${instances_sequence}

### DIFF
--- a/internal/configure/hosts/hc_get.go
+++ b/internal/configure/hosts/hc_get.go
@@ -25,25 +25,24 @@
 package hosts
 
 import (
-	comm "github.com/opencurve/curveadm/internal/configure/common"
 	"github.com/opencurve/curveadm/internal/configure/curveadm"
 	"github.com/opencurve/curveadm/internal/utils"
 	"github.com/opencurve/curveadm/pkg/module"
 )
 
-func (hc *HostConfig) get(i *comm.Item) interface{} {
+func (hc *HostConfig) get(i *item) interface{} {
 	if v, ok := hc.config[i.Key()]; ok {
 		return v
 	}
 
-	defaultValue := i.DefaultValue()
+	defaultValue := i.defaultValue
 	if defaultValue != nil && utils.IsFunc(defaultValue) {
 		return defaultValue.(func(*HostConfig) interface{})(hc)
 	}
 	return defaultValue
 }
 
-func (hc *HostConfig) getString(i *comm.Item) string {
+func (hc *HostConfig) getString(i *item) string {
 	v := hc.get(i)
 	if v == nil {
 		return ""
@@ -51,7 +50,7 @@ func (hc *HostConfig) getString(i *comm.Item) string {
 	return v.(string)
 }
 
-func (hc *HostConfig) getInt(i *comm.Item) int {
+func (hc *HostConfig) getInt(i *item) int {
 	v := hc.get(i)
 	if v == nil {
 		return 0
@@ -59,7 +58,7 @@ func (hc *HostConfig) getInt(i *comm.Item) int {
 	return v.(int)
 }
 
-func (hc *HostConfig) getBool(i *comm.Item) bool {
+func (hc *HostConfig) getBool(i *item) bool {
 	v := hc.get(i)
 	if v == nil {
 		return false
@@ -77,6 +76,8 @@ func (hc *HostConfig) GetForwardAgent() bool     { return hc.getBool(CONFIG_FORW
 func (hc *HostConfig) GetBecomeUser() string     { return hc.getString(CONFIG_BECOME_USER) }
 func (hc *HostConfig) GetLabels() []string       { return hc.labels }
 func (hc *HostConfig) GetEnvs() []string         { return hc.envs }
+func (hc *HostConfig) GetInstances() int         { return hc.instances }
+func (hc *HostConfig) GetInstancesSequence() int { return hc.instances_sequence }
 func (hc *HostConfig) GetSSHConfig() *module.SSHConfig {
 	hostname := hc.GetSSHHostname()
 	if len(hostname) == 0 {

--- a/internal/configure/hosts/hosts.go
+++ b/internal/configure/hosts/hosts.go
@@ -26,18 +26,22 @@ package hosts
 
 import (
 	"bytes"
+	"github.com/opencurve/curveadm/pkg/variable"
+	"strconv"
 	"strings"
 
 	"github.com/opencurve/curveadm/internal/build"
 	"github.com/opencurve/curveadm/internal/configure/os"
 	"github.com/opencurve/curveadm/internal/errno"
 	"github.com/opencurve/curveadm/internal/utils"
+	log "github.com/opencurve/curveadm/pkg/log/glg"
 	"github.com/spf13/viper"
 )
 
 const (
-	KEY_LABELS = "labels"
-	KEY_ENVS   = "envs"
+	KEY_LABELS    = "labels"
+	KEY_ENVS      = "envs"
+	KEY_INSTANCES = "instances"
 
 	PERMISSIONS_600 = 384 // -rw------- (256 + 128 = 384)
 )
@@ -53,6 +57,11 @@ type (
 		config   map[string]interface{}
 		labels   []string
 		envs     []string
+		//instances and instances_sequence only used in the memcached deploy
+		//instances is the num of memcached servers will be deployed in the same host
+		instances int
+		//instances_sequence is the sequence num of memcached servers in the same host
+		instances_sequence int
 	}
 )
 
@@ -111,6 +120,80 @@ func (hc *HostConfig) convertEnvs() error {
 	return nil
 }
 
+// read the instances value from hc.config
+func (hc *HostConfig) convertInstances() error {
+	value := hc.config[KEY_INSTANCES]
+	v, ok := utils.All2Str(value)
+	if !ok {
+		if !utils.IsAnySlice(value) {
+			return errno.ERR_UNSUPPORT_CONFIGURE_VALUE_TYPE.
+				F("hosts[%d].%s = %v", hc.sequence, KEY_INSTANCES, value)
+		}
+	}
+	if v, ok := utils.Str2Int(v); !ok {
+		return errno.ERR_CONFIGURE_VALUE_REQUIRES_INTEGER.
+			F("hosts[%d].%s = %v", hc.sequence, KEY_INSTANCES, value)
+	} else if v <= 0 {
+		return errno.ERR_CONFIGURE_VALUE_REQUIRES_POSITIVE_INTEGER.
+			F("hosts[%d].%s = %v", hc.sequence, KEY_INSTANCES, value)
+	} else {
+		hc.instances = v
+		return nil
+	}
+}
+
+// convret config item to its require type after rendering,
+// return error if convert failed
+func (hc *HostConfig) convert() error {
+	for _, item := range itemset.getAll() {
+		k := item.key
+		value := hc.get(item) // return config value or default value
+		if value == nil {
+			continue
+		}
+		v, ok := utils.All2Str(value)
+		if !ok {
+			return errno.ERR_UNSUPPORT_CONFIGURE_VALUE_TYPE.
+				F("%s: %v", k, value)
+		}
+
+		switch item.require {
+		case REQUIRE_ANY:
+			// do nothing
+		case REQUIRE_INT:
+			if intv, ok := utils.Str2Int(v); !ok {
+				return errno.ERR_CONFIGURE_VALUE_REQUIRES_INTEGER.
+					F("%s: %v", k, value)
+			} else {
+				hc.config[k] = intv
+			}
+		case REQUIRE_STRING:
+			if len(v) == 0 {
+				return errno.ERR_CONFIGURE_VALUE_REQUIRES_NON_EMPTY_STRING.
+					F("%s: %v", k, value)
+			}
+		case REQUIRE_BOOL:
+			if boolv, ok := utils.Str2Bool(v); !ok {
+				return errno.ERR_CONFIGURE_VALUE_REQUIRES_BOOL.
+					F("%s: %v", k, value)
+			} else {
+				hc.config[k] = boolv
+			}
+		case REQUIRE_POSITIVE_INTEGER:
+			if intv, ok := utils.Str2Int(v); !ok {
+				return errno.ERR_CONFIGURE_VALUE_REQUIRES_INTEGER.
+					F("%s: %v", k, value)
+			} else if intv <= 0 {
+				return errno.ERR_CONFIGURE_VALUE_REQUIRES_POSITIVE_INTEGER.
+					F("%s: %v", k, value)
+			} else {
+				hc.config[k] = intv
+			}
+		}
+	}
+	return nil
+}
+
 func (hc *HostConfig) Build() error {
 	for key, value := range hc.config {
 		if key == KEY_LABELS { // convert labels
@@ -123,11 +206,17 @@ func (hc *HostConfig) Build() error {
 			if err := hc.convertEnvs(); err != nil {
 				return err
 			}
-			hc.config[key] = nil // delete labels section
+			hc.config[key] = nil // delete envs section
+			continue
+		} else if key == KEY_INSTANCES { // convert instances
+			if err := hc.convertInstances(); err != nil {
+				return err
+			}
+			hc.config[key] = nil // delete instances section
 			continue
 		}
 
-		if itemset.Get(key) == nil {
+		if itemset.get(key) == nil {
 			return errno.ERR_UNSUPPORT_HOSTS_CONFIGURE_ITEM.
 				F("hosts[%d].%s = %v", hc.sequence, key, value)
 		}
@@ -170,11 +259,110 @@ func (hc *HostConfig) Build() error {
 	return nil
 }
 
+// "PORT=1121${instances_sequence}" -> "PORT=11211"
+func (hc *HostConfig) renderInstancesSequence() error {
+	//0. create vars
+	vars := variable.NewVariables()
+	if err := vars.Register(variable.Variable{
+		Name:        "instances_sequence",
+		Description: "the sequence of memcache server of one host",
+		Value:       strconv.Itoa(hc.GetInstancesSequence()),
+	}); err != nil {
+		return err
+	}
+	//1. all config to str
+	for k, v := range hc.config {
+		if v == nil {
+			continue
+		}
+		if strv, ok := utils.All2Str(v); ok {
+			hc.config[k] = strv
+		} else {
+			return errno.ERR_UNSUPPORT_CONFIGURE_VALUE_TYPE.
+				F("%s: %v", k, v)
+		}
+	}
+	//2. rendering
+	if err := vars.Build(); err != nil {
+		log.Error("Build variables failed",
+			log.Field("error", err))
+		return errno.ERR_RESOLVE_VARIABLE_FAILED.E(err)
+	}
+	//render labels
+	for i := range hc.labels {
+		err := func(value *string) error {
+			realValue, err := vars.Rendering(*value)
+			if err != nil {
+				return err
+			}
+			*value = realValue
+			return nil
+		}(&hc.labels[i])
+		if err != nil {
+			return errno.ERR_RENDERING_VARIABLE_FAILED.E(err)
+		}
+	}
+	//render envs
+	for i := range hc.envs {
+		err := func(value *string) error {
+			realValue, err := vars.Rendering(*value)
+			if err != nil {
+				return err
+			}
+			*value = realValue
+			return nil
+		}(&hc.envs[i])
+		if err != nil {
+			return errno.ERR_RENDERING_VARIABLE_FAILED.E(err)
+		}
+	}
+	//render config
+	for k, v := range hc.config {
+		if v == nil {
+			continue
+		}
+		realv, err := vars.Rendering(v.(string))
+		if err != nil {
+			return errno.ERR_RENDERING_VARIABLE_FAILED.E(err)
+		}
+		hc.config[k] = realv
+		build.DEBUG(build.DEBUG_TOPOLOGY,
+			build.Field{Key: k, Value: v},
+			build.Field{Key: k, Value: realv})
+	}
+
+	//3. convert config item to its require type after rendering,
+	//	 return error if convert failed
+	return hc.convert()
+}
+
 func NewHostConfig(sequence int, config map[string]interface{}) *HostConfig {
 	return &HostConfig{
 		sequence: sequence,
 		config:   config,
 		labels:   []string{},
+		envs:     []string{},
+		//instances and instances_sequence only used in the memcached deploy
+		instances:          1,
+		instances_sequence: 1,
+	}
+}
+
+// deepcopy a HostConfig with instances_sequence and return it
+func replicateHostConfig(src *HostConfig, instances_sequence int) *HostConfig {
+	//deepcopy labels
+	newlabels := make([]string, len(src.labels))
+	copy(newlabels, src.labels)
+	//deepcopy envs
+	newenvs := make([]string, len(src.envs))
+	copy(newenvs, src.envs)
+	return &HostConfig{
+		sequence:           src.sequence,
+		config:             utils.DeepCopy(src.config),
+		labels:             newlabels,
+		envs:               newenvs,
+		instances:          src.instances,
+		instances_sequence: instances_sequence,
 	}
 }
 
@@ -182,7 +370,6 @@ func ParseHosts(data string) ([]*HostConfig, error) {
 	if len(data) == 0 {
 		return nil, errno.ERR_EMPTY_HOSTS
 	}
-
 	parser := viper.NewWithOptions(viper.KeyDelimiter("::"))
 	parser.SetConfigType("yaml")
 	err := parser.ReadConfig(bytes.NewBuffer([]byte(data)))
@@ -210,7 +397,15 @@ func ParseHosts(data string) ([]*HostConfig, error) {
 			return nil, errno.ERR_DUPLICATE_HOST.
 				F("duplicate host: %s", hc.GetHost())
 		}
-		hcs = append(hcs, hc)
+		//produce the instances of hc, then render the hc_new, last append to hcs.
+		instances := hc.GetInstances()
+		for i := 1; i <= instances; i++ {
+			hc_new := replicateHostConfig(hc, i)
+			if err := hc_new.renderInstancesSequence(); err != nil {
+				return nil, err
+			}
+			hcs = append(hcs, hc_new)
+		}
 		exist[hc.GetHost()] = true
 	}
 	build.DEBUG(build.DEBUG_HOSTS, hosts)

--- a/playbook/memcached/hosts_instances.yaml
+++ b/playbook/memcached/hosts_instances.yaml
@@ -1,0 +1,46 @@
+global:
+  user: curve
+  ssh_port: 22
+  private_key_file: /home/curve/.ssh/id_rsa
+
+hosts:
+  - host: server-host1
+    hostname: 10.0.1.1
+    labels:
+      - memcached
+    envs:
+      - SUDO_ALIAS=sudo
+      - ENGINE=docker
+      - IMAGE=memcached:1.6.17
+      - EXPORTER_IMAGE=quay.io/prometheus/memcached-exporter:v0.13.0
+      - LISTEN=10.0.1.1
+      - PORT=1121${instances_sequence}
+      - EXPORTER_PORT=915${instances_sequence}
+      - USER=root
+      - MEMORY_LIMIT=32768 # item memory in megabytes
+      - MAX_ITEM_SIZE=8m # adjusts max item size (default: 1m, min: 1k, max: 1024m)
+      - EXT_PATH=/mnt/memcachefile/cachefile:102${instances_sequence}G
+      - EXT_WBUF_SIZE=8 # size in megabytes of page write buffers.
+      - EXT_ITEM_AGE=1 # store items idle at least this long (seconds, default: no age limit)
+      - VERBOSE="v"
+    instances: 3
+
+  - host: server-host2
+    hostname: 10.0.1.2
+    labels:
+      - memcached
+    envs:
+      - SUDO_ALIAS=sudo
+      - ENGINE=docker
+      - IMAGE=memcached:1.6.17
+      - EXPORTER_IMAGE=quay.io/prometheus/memcached-exporter:v0.13.0
+      - LISTEN=10.0.1.2
+      - PORT=11211
+      - EXPORTER_PORT=9151
+      - USER=root
+      - MEMORY_LIMIT=32768 # item memory in megabytes
+      - MAX_ITEM_SIZE=8m # adjusts max item size (default: 1m, min: 1k, max: 1024m)
+      - EXT_PATH=/mnt/memcachefile/cachefile:1024G
+      - EXT_WBUF_SIZE=8 # size in megabytes of page write buffers.
+      - EXT_ITEM_AGE=1 # store items idle at least this long (seconds, default: no age limit)
+      - VERBOSE="v"

--- a/playbook/memcached/scripts/clean.sh
+++ b/playbook/memcached/scripts/clean.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 g_container_name="memcached-"${PORT}
-g_expoter_container_name="memcached-exporter-"${EXPORTER_PORT}
+g_exporter_container_name="memcached-exporter-"${EXPORTER_PORT}
 g_docker_cmd="${SUDO_ALIAS} ${ENGINE}"
 g_rm_cmd="${SUDO_ALIAS} rm -rf"
 
@@ -25,9 +25,9 @@ precheck() {
         exit 1
     fi
     if [ "${EXPORTER_PORT}" ];then
-        container_id=`${g_docker_cmd} ps --all --format "{{.ID}}" --filter name=${g_expoter_container_name}`
+        container_id=`${g_docker_cmd} ps --all --format "{{.ID}}" --filter name=${g_exporter_container_name}`
         if [ -z ${container_id} ]; then
-            die "container [${g_expoter_container_name}] not exists!!!\n"
+            die "container [${g_exporter_container_name}] not exists!!!\n"
             exit 1
         fi
     fi
@@ -41,12 +41,12 @@ stop_container() {
     fi
     success "rm container[${g_container_name}]\n"
     if [ "${EXPORTER_PORT}" ];then
-        msg=`${g_docker_cmd} rm ${g_expoter_container_name}`
+        msg=`${g_docker_cmd} rm ${g_exporter_container_name}`
         if [ $? -ne 0 ];then
             die "${msg}\n"
             exit 1
         fi
-        success "rm container[${g_expoter_container_name}]\n"
+        success "rm container[${g_exporter_container_name}]\n"
     fi
 }
 

--- a/playbook/memcached/scripts/start.sh
+++ b/playbook/memcached/scripts/start.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 g_container_name="memcached-"${PORT}
+g_exporter_container_name="memcached-exporter-"${EXPORTER_PORT}
 g_docker_cmd="${SUDO_ALIAS} ${ENGINE}"
 g_rm_cmd="${SUDO_ALIAS} rm -rf"
 g_mkdir_cmd="${SUDO_ALIAS} mkdir -p"
@@ -34,6 +35,10 @@ precheck() {
 start_container() {
     ${g_docker_cmd} start ${g_container_name} >& /dev/null
     success "start container[${g_container_name}]\n"
+    if [ "${EXPORTER_PORT}" ];then
+        ${g_docker_cmd} start ${g_exporter_container_name} >& /dev/null
+        success "start container[${g_exporter_container_name}]\n"
+    fi
 }
 
 get_status_container() {

--- a/playbook/memcached/scripts/status.sh
+++ b/playbook/memcached/scripts/status.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 g_container_name="memcached-"${PORT}
-g_expoter_container_name="memcached-exporter-"${EXPORTER_PORT}
+g_exporter_container_name="memcached-exporter-"${EXPORTER_PORT}
 g_start_args=""
 g_docker_cmd="${SUDO_ALIAS} ${ENGINE}"
 g_volume_bind=""
@@ -27,9 +27,9 @@ precheck() {
         exit 1
     fi
     if [ "${EXPORTER_PORT}" ];then
-        g_container_id=`${g_docker_cmd} ps --all --format "{{.ID}}" --filter name=${g_expoter_container_name}`
+        g_container_id=`${g_docker_cmd} ps --all --format "{{.ID}}" --filter name=${g_exporter_container_name}`
         if [ -z ${g_container_id} ]; then
-            success "container [${g_expoter_container_name}] not exists!!!"
+            success "container [${g_exporter_container_name}] not exists!!!"
             exit 1
         fi
     fi
@@ -37,12 +37,16 @@ precheck() {
 
 show_info_container() {
     ${g_docker_cmd} ps --all --filter "name=${g_container_name}" --format="table {{.ID}}\t{{.Names}}\t{{.Status}}"
-    ${g_docker_cmd} ps --all --filter "name=${g_expoter_container_name}" --format="table {{.ID}}\t{{.Names}}\t{{.Status}}"
+    if [ "${EXPORTER_PORT}" ];then
+        ${g_docker_cmd} ps --all --filter "name=${g_exporter_container_name}" --format="table {{.ID}}\t{{.Names}}\t{{.Status}}"
+    fi
 }
 
 show_ip_port() {
     printf "memcached addr:\t%s:%d\n" ${LISTEN} ${PORT}
-    printf "memcached-expoter addr:\t%s:%d\n" ${LISTEN} ${EXPORTER_PORT}
+    if [ "${EXPORTER_PORT}" ];then
+        printf "memcached-exporter addr:\t%s:%d\n" ${LISTEN} ${EXPORTER_PORT}
+    fi
 }
 
 get_status_container() {
@@ -51,7 +55,7 @@ get_status_container() {
             exit 1
     fi
     if [ "${EXPORTER_PORT}" ];then
-        status=`${g_docker_cmd} inspect --format='{{.State.Status}}' ${g_expoter_container_name}`
+        status=`${g_docker_cmd} inspect --format='{{.State.Status}}' ${g_exporter_container_name}`
         if [ ${status} != "running" ]; then
             exit 1
         fi

--- a/playbook/memcached/scripts/stop.sh
+++ b/playbook/memcached/scripts/stop.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 g_container_name="memcached-"${PORT}
-g_expoter_container_name="memcached-exporter-"${EXPORTER_PORT}
+g_exporter_container_name="memcached-exporter-"${EXPORTER_PORT}
 g_docker_cmd="${SUDO_ALIAS} ${ENGINE}"
 
 function msg() {
@@ -24,9 +24,9 @@ precheck() {
         exit 1
     fi
     if [ "${EXPORTER_PORT}" ];then
-        container_id=`${g_docker_cmd} ps --all --format "{{.ID}}" --filter name=${g_expoter_container_name}`
+        container_id=`${g_docker_cmd} ps --all --format "{{.ID}}" --filter name=${g_exporter_container_name}`
         if [ -z ${container_id} ]; then
-            die "container [${g_expoter_container_name}] not exists!!!\n"
+            die "container [${g_exporter_container_name}] not exists!!!\n"
             exit 1
         fi
     fi
@@ -36,8 +36,8 @@ stop_container() {
     ${g_docker_cmd} stop ${g_container_name} >& /dev/null
     success "stop container[${g_container_name}]\n"
     if [ "${EXPORTER_PORT}" ];then
-        ${g_docker_cmd} stop ${g_expoter_container_name} >& /dev/null
-        success "stop container[${g_expoter_container_name}]\n"
+        ${g_docker_cmd} stop ${g_exporter_container_name} >& /dev/null
+        success "stop container[${g_exporter_container_name}]\n"
     fi
 }
 


### PR DESCRIPTION
fix #240 
1. hosts.yaml support the instances. 
2. add the hosts_instances.yaml as a template. 
3. Fixed spelling errors in variable names: "expoter" -> "exporter". 
4. add "if [ "${EXPORTER_PORT}" ];then".

Now, when deploying the memcached cluster, hosts.yaml can be written as follows：
```
global:
  user: curve
  ssh_port: 22
  private_key_file: /home/curve/.ssh/id_rsa
  
hosts:
  - host: server-host1
    hostname: 10.0.1.1
    labels:
      - memcached
    envs:
      - SUDO_ALIAS=sudo
      - ENGINE=docker
      - IMAGE=memcached:1.6.17
      - EXPORTER_IMAGE=quay.io/prometheus/memcached-exporter:v0.13.0
      - LISTEN=10.0.1.1
      - PORT=1121${instances_sequence}
      - EXPORTER_PORT=915${instances_sequence}
      - USER=root
      - MEMORY_LIMIT=32768 # item memory in megabytes
      - MAX_ITEM_SIZE=8m # adjusts max item size (default: 1m, min: 1k, max: 1024m)
      - EXT_PATH=/mnt/memcachefile/cachefile:102${instances_sequence}G
      - EXT_WBUF_SIZE=8 # size in megabytes of page write buffers.
      - EXT_ITEM_AGE=1 # store items idle at least this long (seconds, default: no age limit)
      - VERBOSE="v"
    instances: 3

  - host: server-host2
    hostname: 10.0.1.2
    labels:
      - memcached
    envs:
      - SUDO_ALIAS=sudo
      - ENGINE=docker
      - IMAGE=memcached:1.6.17
      - EXPORTER_IMAGE=quay.io/prometheus/memcached-exporter:v0.13.0
      - LISTEN=10.0.1.2
      - PORT=11211
      - EXPORTER_PORT=9151
      - USER=root
      - MEMORY_LIMIT=32768 # item memory in megabytes
      - MAX_ITEM_SIZE=8m # adjusts max item size (default: 1m, min: 1k, max: 1024m)
      - EXT_PATH=/mnt/memcachefile/cachefile:1024G
      - EXT_WBUF_SIZE=8 # size in megabytes of page write buffers.
      - EXT_ITEM_AGE=1 # store items idle at least this long (seconds, default: no age limit)
      - VERBOSE="v"
```
