### PR TITLE
[FIX]: make build error with musl1.2.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,13 @@ GOPROXY     := "https://goproxy.cn,direct"
 GOOS        := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
 GOARCH      := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
 CGO_LDFLAGS := "-static"
+CGO_CFLAGS  := "-D_LARGEFILE64_SOURCE"
 CC          := musl-gcc
 
 GOENV := GO111MODULE=on
 GOENV += GOPROXY=$(GOPROXY)
 GOENV += CC=$(CC)
-GOENV += CGO_ENABLED=1 CGO_LDFLAGS=$(CGO_LDFLAGS)
+GOENV += CGO_ENABLED=1 CGO_LDFLAGS=$(CGO_LDFLAGS) CGO_CFLAGS=$(CGO_CFLAGS)
 GOENV += GOOS=$(GOOS) GOARCH=$(GOARCH)
 GOLANGCILINT_VERSION ?= v1.50.0
 GOBIN := $(shell go env GOPATH)/bin


### PR DESCRIPTION
Related [issue](https://github.com/opencurve/curveadm/issues/354).

Fix `make build` error with musl1.2.4. This error is because LFS64 interfaces were marked as deprecated ([release notes](https://musl.libc.org/releases.html), [commit](https://git.musl-libc.org/cgit/musl/commit/?h=v1.2.4&id=25e6fee27f4a293728dd15b659170e7b9c7db9bc)). 