### PR TITLE
Fix (target start): curveadm target start timeout

### DIFF
--- a/internal/task/step/container.go
+++ b/internal/task/step/container.go
@@ -119,6 +119,7 @@ type (
 	ContainerExec struct {
 		ContainerId *string
 		Command     string
+		Detached    bool
 		Success     *bool
 		Out         *string
 		module.ExecOptions
@@ -289,6 +290,9 @@ func (s *ListContainers) Execute(ctx *context.Context) error {
 
 func (s *ContainerExec) Execute(ctx *context.Context) error {
 	cli := ctx.Module().DockerCli().ContainerExec(*s.ContainerId, s.Command)
+	if s.Detached {
+		cli.AddOption("--detach")
+	}
 	out, err := cli.Execute(s.ExecOptions)
 	return PostHandle(s.Success, s.Out, out, err, errno.ERR_RUN_COMMAND_IN_CONTAINER_FAILED.FD("(%s exec CONTAINER COMMAND)", s.ExecWithEngine))
 }

--- a/internal/task/task/bs/start_tgtd.go
+++ b/internal/task/task/bs/start_tgtd.go
@@ -127,7 +127,8 @@ func NewStartTargetDaemonTask(curveadm *cli.CurveAdm, cc *configure.ClientConfig
 		ExecOptions: curveadm.ExecOptions(),
 	})
 	t.AddStep(&step.ContainerExec{
-		Command:     "tgtd -f &",
+		Command:     "tgtd -f",
+		Detached:    true,
 		ContainerId: &containerId,
 		ExecOptions: curveadm.ExecOptions(),
 	})


### PR DESCRIPTION
Related to this [issue](https://github.com/opencurve/curveadm/issues/291).

In curve tgt deployment, we start the tgtd daemon on the specified host using `curveadm target start --host target-host -c client.yaml`. This command will timeout but in fact, the tgtd has been started.

![image](https://github.com/opencurve/curveadm/assets/50295684/89be4208-5ec0-4690-82e8-507f84266077)

Looking through these codes, I found this command is mainly executed by `sudo docker exec <ContianerId> tgtd -f &` on the remote host and we need to wait its returns (combined stdout and stderr) to end with no error. But since `sudo docker exec <ContianerId> tgtd -f &` executes in non-detached mode, it will occupy its stdout, which causes the callback function can't return and then timeout.

So, I try to add `-d` parameter to ContainerExec, which makes tgtd running in detached mode correctly.