### PR TITLE
Impove(enter): enter leader mds directly without id option

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -49,6 +49,7 @@ const (
 	POOLSET                   = "poolset"
 	POOLSET_DISK_TYPE         = "poolset-disktype"
 	KEY_NUMBER_OF_CHUNKSERVER = "NUMBER_OF_CHUNKSERVER"
+	LEADER_OR_RANDOM_ID       = "LEADER_OR_RANDOM_ID"
 
 	// format
 	KEY_ALL_FORMAT_STATUS = "ALL_FORMAT_STATUS"

--- a/internal/errno/errno.go
+++ b/internal/errno/errno.go
@@ -253,8 +253,10 @@ var (
 	ERR_UNSUPPORT_CLEAN_ITEM           = EC(210005, "unsupport clean item")
 	ERR_NO_SERVICES_MATCHED            = EC(210006, "no services matched")
 	// TODO: please check pool set disk type
-	ERR_INVALID_DISK_TYPE = EC(210007, "poolset disk type must be lowercase and can only be one of ssd, hdd and nvme")
-	ERR_UNSUPPORT_DEPLOY_TYPE          = EC(210008, "unknown deploy type")
+	ERR_INVALID_DISK_TYPE                   = EC(210007, "poolset disk type must be lowercase and can only be one of ssd, hdd and nvme")
+	ERR_UNSUPPORT_DEPLOY_TYPE               = EC(210008, "unknown deploy type")
+	ERR_NO_LEADER_OR_RANDOM_CONTAINER_FOUND = EC(210009, "no leader or random container found")
+	
 	// 220: commad options (client common)
 	ERR_UNSUPPORT_CLIENT_KIND = EC(220000, "unsupport client kind")
 	// 221: command options (client/bs)

--- a/internal/playbook/factory.go
+++ b/internal/playbook/factory.go
@@ -83,6 +83,7 @@ const (
 	GET_CLIENT_STATUS
 	INSTALL_CLIENT
 	UNINSTALL_CLIENT
+	ATTACH_LEADER_OR_RANDOM_CONTAINER
 
 	// bs
 	FORMAT_CHUNKFILE_POOL
@@ -225,6 +226,8 @@ func (p *Playbook) createTasks(step *PlaybookStep) (*tasks.Tasks, error) {
 			t, err = comm.NewInitServiceStatusTask(curveadm, config.GetDC(i))
 		case GET_SERVICE_STATUS:
 			t, err = comm.NewGetServiceStatusTask(curveadm, config.GetDC(i))
+		case ATTACH_LEADER_OR_RANDOM_CONTAINER:
+			t, err = comm.NewAttachLeaderOrRandomContainerTask(curveadm, config.GetDC(i))
 		case CLEAN_SERVICE:
 			t, err = comm.NewCleanServiceTask(curveadm, config.GetDC(i))
 		case INIT_SUPPORT:


### PR DESCRIPTION
fix #324 
Modify the enter command to directly enter the leader container without any parameter