### PR TITLE
1.add http deployment method

### DIFF
--- a/cli/cli/cli.go
+++ b/cli/cli/cli.go
@@ -35,6 +35,7 @@ import (
 	configure "github.com/opencurve/curveadm/internal/configure/curveadm"
 	"github.com/opencurve/curveadm/internal/configure/hosts"
 	"github.com/opencurve/curveadm/internal/configure/topology"
+	"github.com/opencurve/curveadm/internal/daemon"
 	"github.com/opencurve/curveadm/internal/errno"
 	"github.com/opencurve/curveadm/internal/storage"
 	tools "github.com/opencurve/curveadm/internal/tools/upgrade"
@@ -43,6 +44,7 @@ import (
 	cliutil "github.com/opencurve/curveadm/internal/utils"
 	log "github.com/opencurve/curveadm/pkg/log/glg"
 	"github.com/opencurve/curveadm/pkg/module"
+	pigeoncore "github.com/opencurve/pigeon"
 )
 
 type CurveAdm struct {
@@ -70,6 +72,9 @@ type CurveAdm struct {
 	clusterTopologyData string // cluster topology
 	clusterPoolData     string // cluster pool
 	monitor             storage.Monitor
+
+	// pigeon
+	pigeon *pigeoncore.Pigeon
 }
 
 /*
@@ -195,7 +200,8 @@ func (curveadm *CurveAdm) init() error {
 	curveadm.clusterTopologyData = cluster.Topology
 	curveadm.clusterPoolData = cluster.Pool
 	curveadm.monitor = monitor
-
+	admServer := daemon.NewServer()
+	curveadm.pigeon = pigeoncore.NewPigeon([]*pigeoncore.HTTPServer{admServer})
 	return nil
 }
 
@@ -533,4 +539,8 @@ func (curveadm *CurveAdm) PostAudit(id int64, ec error) {
 		log.Error("Set audit log status failed",
 			log.Field("Error", err))
 	}
+}
+
+func (curveadm *CurveAdm) GetPigeon() *pigeoncore.Pigeon {
+	return curveadm.pigeon
 }

--- a/cli/command/cmd.go
+++ b/cli/command/cmd.go
@@ -31,6 +31,7 @@ import (
 	"github.com/opencurve/curveadm/cli/command/client"
 	"github.com/opencurve/curveadm/cli/command/cluster"
 	"github.com/opencurve/curveadm/cli/command/config"
+	"github.com/opencurve/curveadm/cli/command/daemon"
 	"github.com/opencurve/curveadm/cli/command/hosts"
 	"github.com/opencurve/curveadm/cli/command/monitor"
 	"github.com/opencurve/curveadm/cli/command/pfs"
@@ -66,6 +67,7 @@ func addSubCommands(cmd *cobra.Command, curveadm *cli.CurveAdm) {
 		target.NewTargetCommand(curveadm),         // curveadm target ...
 		pfs.NewPFSCommand(curveadm),               // curveadm pfs ...
 		monitor.NewMonitorCommand(curveadm),       // curveadm monitor ...
+		daemon.NewDaemonCommand(curveadm),         // curveadm http
 
 		NewAuditCommand(curveadm),      // curveadm audit
 		NewCleanCommand(curveadm),      // curveadm clean

--- a/cli/command/daemon/cmd.go
+++ b/cli/command/daemon/cmd.go
@@ -1,0 +1,44 @@
+/*
+*  Copyright (c) 2023 NetEase Inc.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+ */
+
+/*
+* Project: Curveadm
+* Created Date: 2023-03-31
+* Author: wanghai (SeanHai)
+ */
+
+package daemon
+
+import (
+	"github.com/opencurve/curveadm/cli/cli"
+	cliutil "github.com/opencurve/curveadm/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+func NewDaemonCommand(curveadm *cli.CurveAdm) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "daemon",
+		Short: "Manage http service",
+		Args:  cliutil.NoArgs,
+		RunE:  cliutil.ShowHelp(curveadm.Err()),
+	}
+
+	cmd.AddCommand(
+		NewStartCommand(curveadm),
+		NewStopCommand(curveadm),
+	)
+	return cmd
+}

--- a/cli/command/daemon/start.go
+++ b/cli/command/daemon/start.go
@@ -1,0 +1,58 @@
+/*
+*  Copyright (c) 2023 NetEase Inc.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+ */
+
+/*
+* Project: Curveadm
+* Created Date: 2023-03-31
+* Author: wanghai (SeanHai)
+ */
+
+package daemon
+
+import (
+	"github.com/opencurve/curveadm/cli/cli"
+	"github.com/spf13/cobra"
+)
+
+const (
+	START_EXAMPLR = `Examples:
+  $ curveadm daemon start -c config/pigeon.yaml  # Start an http service to receive requests`
+)
+
+type startOptions struct {
+	filename string
+}
+
+func NewStartCommand(curveadm *cli.CurveAdm) *cobra.Command {
+	var options startOptions
+	pigeon := curveadm.GetPigeon()
+
+	cmd := &cobra.Command{
+		Use:     "start [OPTIONS]",
+		Short:   "Start http service",
+		Example: START_EXAMPLR,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return pigeon.Start(options.filename)
+		},
+		DisableFlagsInUseLine: true,
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&options.filename, "conf", "c", pigeon.DefaultConfFile(),
+		"Specify pigeon configure file")
+
+	return cmd
+}

--- a/cli/command/daemon/stop.go
+++ b/cli/command/daemon/stop.go
@@ -1,0 +1,60 @@
+/*
+*  Copyright (c) 2023 NetEase Inc.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+ */
+
+/*
+* Project: Curveadm
+* Created Date: 2023-03-31
+* Author: wanghai (SeanHai)
+ */
+
+package daemon
+
+import (
+	"github.com/opencurve/curveadm/cli/cli"
+	cliutil "github.com/opencurve/curveadm/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+const (
+	STOP_EXAMPLR = `Examples:
+  $ curveadm daemon stop -c config/pigeon.yaml  # Stop an http service`
+)
+
+type stopOptions struct {
+	filename string
+}
+
+func NewStopCommand(curveadm *cli.CurveAdm) *cobra.Command {
+	var options stopOptions
+	pigeon := curveadm.GetPigeon()
+
+	cmd := &cobra.Command{
+		Use:     "stop",
+		Short:   "Stop http service",
+		Args:    cliutil.NoArgs,
+		Example: STOP_EXAMPLR,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return pigeon.Stop(options.filename)
+		},
+		DisableFlagsInUseLine: true,
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&options.filename, "conf", "c", pigeon.DefaultConfFile(),
+		"Specify pigeon configure file")
+
+	return cmd
+}

--- a/docs/en/curveadm-architecture-with-cobra.md
+++ b/docs/en/curveadm-architecture-with-cobra.md
@@ -1,0 +1,258 @@
+# Curveadm CLI Development
+
+## Cobra library
+
+Curveadm CLI is developed based on the [Cobra](https://github.com/spf13/cobra) library, a Go language library for creating CLI command line programs.
+
+### Basic use of Cobra
+
+Create a root command using Cobra (print `root command` on the command line):
+```
+package main
+
+import (
+   "fmt"
+   "os"
+   "github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+   Use: "hugo",
+   Short: "Hugo is a very fast static site generator",
+   Long: `A Fast and Flexible Static Site Generator built with
+            love by spf13 and friends in Go.
+            Complete documentation is available at https://gohugo.io/documentation/`,
+   Run: func(cmd *cobra.Command, args []string) {
+     fmt.Println("root command")
+   },
+}
+
+func Execute() {
+   if err := rootCmd.Execute(); err != nil {
+     fmt.Fprintln(os.Stderr, err)
+     os.Exit(1)
+   }
+}
+
+func main() {
+   rootCmd.Execute()
+}
+```
+- Use field sets the name of the command
+- Short field sets a short description
+- Long field setting detailed description
+- The Run field sets the function when executing the command
+
+For more details on `Command` object fields and usage, see [Cobra library--command.go](https://github.com/spf13/cobra/blob/main/command.go).
+
+### flag usage
+
+Cobra supports parsing of custom parameters:
+```
+cmd.PersistentFlags().BoolP("help", "h", false, "Print usage")
+cmd.Flags().BoolVarP(&options.debug, "debug", "d", false, "Print debug information")
+```
+PersistentFlags() is used for global flags and can be used by the current command and its subcommands.
+
+Flags() is used to define local flags, only for the current command.
+
+For more details on the `flag` function and usage, see [Cobra library--command.go](https://github.com/spf13/cobra/blob/main/command.go) and [pflag library](https:// github.com/spf13/pflag).
+
+### hook function
+
+Cobra's Command object supports custom hook functions (PreRun and PostRun fields), and the hook function is run before and after the `run` command is executed. As follows:
+```
+cmd := &cobra.Command{
+   Use: "root [sub]",
+   Short: "My root command",
+   PersistentPreRun: func(cmd *cobra.Command, args []string) {
+       fmt.Printf("Inside rootCmd PersistentPreRun with args: %v\n", args)
+     },
+     PreRun: func(cmd *cobra.Command, args []string) {
+       fmt.Printf("Inside rootCmd PreRun with args: %v\n", args)
+     },
+     Run: func(cmd *cobra.Command, args []string) {
+       fmt.Printf("Inside rootCmd Run with args: %v\n", args)
+     },
+     PostRun: func(cmd *cobra.Command, args []string) {
+       fmt.Printf("Inside rootCmd PostRun with args: %v\n", args)
+     },
+     PersistentPostRun: func(cmd *cobra.Command, args []string) {
+       fmt.Printf("Inside rootCmd PersistentPostRun with args: %v\n", args)
+     },
+}
+```
+The hook function will be executed in the order of (`PersistentPreRun`, `PreRun`, `Run`, `PostRun`, `PersistentPostRun`). Note: If the subcommand does not set `Persistent*Run`, it will automatically inherit the function definition of the parent command.
+
+### Subcommands
+cobra allows nested commands, through the `AddCommand` function of the current command object. As follows:
+```
+rootCmd.AddCommand(versionCmd)
+```
+The recommended hierarchical command nesting structure is as follows:
+```
+├── cmd
+│ ├── root.go
+│ └── sub1
+│ ├── sub1.go
+│ └── sub2
+│ ├── leafA.go
+│ └── leafB.go
+└── main.go
+```
+Add the commands defined in leafA.go and leafB.go to the sub2 command.
+
+Add the commands defined in sub2.go to the sub1 command.
+
+Add the commands defined in sub1.go to the root command.
+
+The main structure of the final command call is as follows:
+```
+root options
+root sub1 options
+root sub1 sub2 options
+root sub1 sub2 leafA options
+root sub1 sub2 leafB options
+```
+
+
+## curveadm cli project structure
+```
+cli
+├── cli
+│ ├── cli.go
+│ └── version.go
+├── command
+│  ├── audit.go
+│ ├── clean.go
+│ ├── client
+│ ├── cluster
+│ ...
+└── curveadm.go
+```
+The `cli.go` in the cli folder defines the `curveadm` object and related methods, which run through all curveadm cli command development.
+```
+type CurveAdm struct {
+   rootDir string
+   dataDir string
+   ...
+}
+func NewCurveAdm() (*CurveAdm, error) {
+   curveadm := &CurveAdm{
+     rootDir: rootDir,
+     ...
+   }
+   ...
+   return curveadm, nil
+}
+```
+
+The command directory stores command implementations at each level.
+```
+├── audit.go
+├── client
+│ ├── cmd.go
+│ ├── enter.go
+│ └── unmap.go
+├── cluster
+│ ├── add.go
+│ ├── cmd.go
+├── cmd.go
+├── deploy.go
+```
+In curveadm cli, the root command of each layer is defined in `cmd.go`. The root command is only responsible for registering subcommands and providing help information, and does not participate in actual work operations.
+```
+cli\command\cmd.go
+
+func addSubCommands(cmd *cobra.Command, curveadm *cli.CurveAdm) {
+   cmd.AddCommand(
+     client.NewClientCommand(curveadm), // curveadm client
+     ...
+   )
+}
+func NewCurveAdmCommand(curveadm *cli.CurveAdm) *cobra.Command {
+   ...
+   cmd := &cobra.Command{
+     Use: "curveadm [OPTIONS] COMMAND [ARGS...]",
+     ...
+   }
+   ...
+   addSubCommands(cmd, curveadm)
+   return cmd
+}
+################################################ ##############
+cli\command\client\cmd.go
+
+func NewClientCommand(curveadm *cli.CurveAdm) *cobra.Command {
+   cmd := &cobra.Command{
+     Use: "client",
+     ...
+   }
+   cmd.AddCommand(
+     NewMapCommand(curveadm),
+     ...
+   )
+   ...
+}
+################################################ ##############
+cli\command\client\enter.go
+
+func NewEnterCommand(curveadm *cli.CurveAdm) *cobra.Command {
+   ...
+   cmd := &cobra.Command{
+     Use: "enter ID",
+     ...
+   }
+   ...
+}
+```
+The final call structure of the enter command is as follows:
+```
+curveadm client enter ID
+```
+
+curveadm.go defines the execution function of the `curveadm` root command and performs related audit work.
+```
+func Execute() {
+   curveadm, err := cli.NewCurveAdm()
+   ...
+   id := curveadm.PreAudit(time.Now(), os.Args[1:])
+   cmd := command.NewCurveAdmCommand(curveadm)
+   err = cmd.Execute()
+   curveadm.PostAudit(id, err)
+   if err != nil {
+     os.Exit(1)
+   }
+}
+```
+
+The entrance to the `curveadm` main program is under the [curveadm folder](https://github.com/opencurve/curveadm/tree/develop/cmd/curveadm). You can execute the operation and execution of `curveadm` in this directory. compile
+```
+func main() {
+   cli.Execute()
+}
+```
+
+### curveadm general tools
+For command development of curveadm cli, curveadm provides general tools, such as:
+
+- cliutil.NoArgs: used to determine whether the command does not contain parameters
+
+- cliutil.ShowHelp: used to display help information when the command is run
+
+In the [curveadm/internal directory](https://github.com/opencurve/curveadm/tree/develop/internal). As follows:
+```
+import (
+   cliutil "github.com/opencurve/curveadm/internal/utils"
+   ...
+)
+
+cmd := &cobra.Command{
+   Use: "client",
+   Args: cliutil.NoArgs,
+   RunE: cliutil.ShowHelp(curveadm.Err()),
+}
+```
+`cliutil.NoArgs` specifies that the `curveadm client` command does not contain any arguments (except subcommands); the `cliutil.ShowHelp` function displays the defined help options when running the `curveadm client` command directly.
+
+For more common commands and usage, please refer to [internal folder](https://github.com/opencurve/curveadm/tree/develop/internal).

--- a/docs/zh/curveadm-architecture-with-cobra.md
+++ b/docs/zh/curveadm-architecture-with-cobra.md
@@ -1,0 +1,258 @@
+# Curveadm CLI 开发
+
+## Cobra库
+
+Curveadm CLI是基于[Cobra](https://github.com/spf13/cobra)库（一个用于创建CLI命令行程序的Go语言库）开发的。
+
+### Cobra的基本使用
+
+使用Cobra创建一个根命令（在命令行打印`root command`）:
+```
+package main
+
+import (
+  "fmt"
+  "os"
+  "github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+  Use:   "hugo",
+  Short: "Hugo is a very fast static site generator",
+  Long: `A Fast and Flexible Static Site Generator built with
+           love by spf13 and friends in Go.
+           Complete documentation is available at https://gohugo.io/documentation/`,
+  Run: func(cmd *cobra.Command, args []string) {
+    fmt.Println("root command")
+  },
+}
+
+func Execute() {
+  if err := rootCmd.Execute(); err != nil {
+    fmt.Fprintln(os.Stderr, err)
+    os.Exit(1)
+  }
+}
+
+func main() {
+  rootCmd.Execute()
+}
+```
+- Use字段设置命令的名字
+- Short字段设置简短描述
+- Long字段设置详细描述
+- Run字段设置执行该命令时的函数
+
+更多`Command`对象字段及用法详见[Cobra库--command.go](https://github.com/spf13/cobra/blob/main/command.go)。
+
+### flag使用
+
+Cobra支持自定义参数的解析：
+```
+cmd.PersistentFlags().BoolP("help", "h", false, "Print usage")
+cmd.Flags().BoolVarP(&options.debug, "debug", "d", false, "Print debug information")
+```
+PersistentFlags()用于全局flag，可以被当前命令及其子命令使用。
+
+Flags()则用于定义本地flag，仅用于当前命令。
+
+更多`flag`函数及用法详见[Cobra库--command.go](https://github.com/spf13/cobra/blob/main/command.go)和[pflag库](https://github.com/spf13/pflag)。
+
+### hook函数
+
+cobra的Command对象支持自定义hook函数（PreRun和PostRun字段），在`run`命令执行前后运行hook函数。如下所示：
+```
+cmd := &cobra.Command{
+  Use:   "root [sub]",
+  Short: "My root command",
+  PersistentPreRun: func(cmd *cobra.Command, args []string) {
+      fmt.Printf("Inside rootCmd PersistentPreRun with args: %v\n", args)
+    },
+    PreRun: func(cmd *cobra.Command, args []string) {
+      fmt.Printf("Inside rootCmd PreRun with args: %v\n", args)
+    },
+    Run: func(cmd *cobra.Command, args []string) {
+      fmt.Printf("Inside rootCmd Run with args: %v\n", args)
+    },
+    PostRun: func(cmd *cobra.Command, args []string) {
+      fmt.Printf("Inside rootCmd PostRun with args: %v\n", args)
+    },
+    PersistentPostRun: func(cmd *cobra.Command, args []string) {
+      fmt.Printf("Inside rootCmd PersistentPostRun with args: %v\n", args)
+    },
+}
+```
+hook函数会按（`PersistentPreRun`、`PreRun`、`Run`、`PostRun`、`PersistentPostRun`）的顺序依次执行。注意：如果子命令没有设置`Persistent*Run`，则会自动继承父命令的函数定义。
+
+### 子命令
+cobra允许嵌套命令，通过当前命令对象的`AddCommand`函数。如下所示：
+```
+rootCmd.AddCommand(versionCmd)
+```
+推荐的层级命令嵌套结构如下：
+```
+├── cmd
+│   ├── root.go
+│   └── sub1
+│       ├── sub1.go
+│       └── sub2
+│           ├── leafA.go
+│           └── leafB.go
+└── main.go
+```
+将 leafA.go 和 leafB.go 中定义的命令添加到 sub2 命令中。
+
+将 sub2.go 中定义的命令添加到 sub1 命令中。
+
+将 sub1.go 中定义的命令添加到 root 命令中。
+
+最终的命令调用的主体结构如下：
+```
+root options
+root sub1 options
+root sub1 sub2 options
+root sub1 sub2 leafA options
+root sub1 sub2 leafB options
+```
+
+
+## curveadm cli项目结构
+```
+cli
+├── cli
+│   ├── cli.go
+│   └── version.go
+├── command
+│   ├── audit.go
+│   ├── clean.go
+│   ├── client
+│   ├── cluster
+│   ...
+└── curveadm.go
+```
+cli 文件夹的`cli.go`定义了`curveadm`对象及相关方法，贯穿所有curveadm cli的命令开发。
+```
+type CurveAdm struct {
+  rootDir      string
+  dataDir      string
+  ...
+}
+func NewCurveAdm() (*CurveAdm, error) {
+  curveadm := &CurveAdm{
+    rootDir:      rootDir,
+    ...
+  }
+  ...
+  return curveadm, nil
+}
+```
+
+command 目录中存放各层级命令实现。
+```
+├── audit.go
+├── client
+│   ├── cmd.go
+│   ├── enter.go
+│   └── unmap.go
+├── cluster
+│   ├── add.go
+│   ├── cmd.go
+├── cmd.go
+├── deploy.go
+```
+在curveadm cli中，每层的根命令都在`cmd.go`定义。根命令只负责注册子命令以及提供帮助信息，并不参与实际工作操作。
+```
+cli\command\cmd.go
+
+func addSubCommands(cmd *cobra.Command, curveadm *cli.CurveAdm) {
+  cmd.AddCommand(
+    client.NewClientCommand(curveadm),         // curveadm client
+    ...
+  )
+}
+func NewCurveAdmCommand(curveadm *cli.CurveAdm) *cobra.Command {
+  ...
+  cmd := &cobra.Command{
+    Use:     "curveadm [OPTIONS] COMMAND [ARGS...]",
+    ...
+  }
+  ...
+  addSubCommands(cmd, curveadm)
+  return cmd
+}
+################################################################
+cli\command\client\cmd.go
+
+func NewClientCommand(curveadm *cli.CurveAdm) *cobra.Command {
+  cmd := &cobra.Command{
+    Use:   "client",
+    ...
+  }
+  cmd.AddCommand(
+    NewMapCommand(curveadm),
+    ...
+  )
+  ...
+}
+################################################################
+cli\command\client\enter.go
+
+func NewEnterCommand(curveadm *cli.CurveAdm) *cobra.Command {
+  ...
+  cmd := &cobra.Command{
+    Use:   "enter ID",
+    ...
+  }
+  ...
+}
+```
+最终enter命令的调用结构如下：
+```
+curveadm client enter ID
+```
+
+curveadm.go 定义了`curveadm` 根命令的执行函数同时执行相关审计工作。
+```
+func Execute() {
+  curveadm, err := cli.NewCurveAdm()
+  ...
+  id := curveadm.PreAudit(time.Now(), os.Args[1:])
+  cmd := command.NewCurveAdmCommand(curveadm)
+  err = cmd.Execute()
+  curveadm.PostAudit(id, err)
+  if err != nil {
+    os.Exit(1)
+  }
+}
+```
+
+`curveadm` 主程序的入口则是在[curveadm文件夹下](https://github.com/opencurve/curveadm/tree/develop/cmd/curveadm)，可以在该目录下执行`curveadm`的运行及编译
+```
+func main() {
+  cli.Execute()
+}
+```
+
+### curveadm 通用工具
+对于curveadm cli的命令开发，curveadm 提供了通用工具，如：
+
+- cliutil.NoArgs：用于判断命令是否不包含参数
+
+- cliutil.ShowHelp：用于在命令运行时展示帮助信息
+
+在[curveadm/internal目录下](https://github.com/opencurve/curveadm/tree/develop/internal)。如下所示：
+```
+import (
+  cliutil "github.com/opencurve/curveadm/internal/utils"
+  ...
+)
+
+cmd := &cobra.Command{
+  Use:   "client",
+  Args:  cliutil.NoArgs,
+  RunE:  cliutil.ShowHelp(curveadm.Err()),
+}
+```
+`cliutil.NoArgs`指明`curveadm client`命令不包含任何参数（子命令除外）；`cliutil.ShowHelp`函数在直接运行`curveadm client`命令时展示定义的帮助选项。
+
+更多通用命令及用法请参考[internal文件夹](https://github.com/opencurve/curveadm/tree/develop/internal)。

--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,11 @@ require (
 	github.com/jpillora/longestcommon v0.0.0-20161227235612-adb9d91ee629
 	github.com/kpango/glg v1.6.14
 	github.com/mattn/go-sqlite3 v1.14.16
+	github.com/mcuadros/go-defaults v1.2.0
 	github.com/melbahja/goph v1.3.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/moby/term v0.0.0-20221205130635-1aeaba878587
+	github.com/opencurve/pigeon v0.0.0-20231207070543-aa3a2494c114
 	github.com/pingcap/log v1.1.0
 	github.com/sergi/go-diff v1.2.0
 	github.com/spf13/cobra v1.7.0
@@ -26,9 +28,46 @@ require (
 )
 
 require (
+	github.com/Wine93/grace v0.0.0-20221021033009-7d0348013a3c // indirect
+	github.com/bytedance/sonic v1.8.7 // indirect
+	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
+	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
+	github.com/facebookgo/grace v0.0.0-20180706040059-75cf19382434 // indirect
+	github.com/facebookgo/httpdown v0.0.0-20180706035922-5979d39b15c2 // indirect
+	github.com/facebookgo/stats v0.0.0-20151006221625-1b76add642e4 // indirect
+	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/gin-gonic/gin v1.9.0 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-playground/validator/v10 v10.12.0 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
+	github.com/golang/mock v1.6.0 // indirect
+	github.com/google/pprof v0.0.0-20230406165453-00490a63f317 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/imroc/req/v3 v3.33.2 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
+	github.com/leodido/go-urn v1.2.3 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/onsi/ginkgo/v2 v2.9.2 // indirect
+	github.com/quic-go/qpack v0.4.0 // indirect
+	github.com/quic-go/qtls-go1-18 v0.2.0 // indirect
+	github.com/quic-go/qtls-go1-19 v0.3.2 // indirect
+	github.com/quic-go/qtls-go1-20 v0.2.2 // indirect
+	github.com/quic-go/quic-go v0.33.0 // indirect
+	github.com/sevlyar/go-daemon v0.1.6 // indirect
+	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+	github.com/ugorji/go/codec v1.2.11 // indirect
+	golang.org/x/arch v0.3.0 // indirect
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
+)
+
+require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
-	github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect
@@ -81,18 +120,21 @@ require (
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/theupdateframework/notary v0.7.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
-	go.uber.org/multierr v1.8.0 // indirect
-	golang.org/x/mod v0.9.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	golang.org/x/term v0.7.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
-	golang.org/x/tools v0.7.0 // indirect
-	google.golang.org/protobuf v1.29.1 // indirect
+	golang.org/x/tools v0.8.0 // indirect
+	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	gotest.tools/v3 v3.0.3 // indirect
 )
 
 replace github.com/melbahja/goph v1.3.0 => github.com/Wine93/goph v0.0.0-20220907033045-3b286d827fb3
+
+replace github.com/quic-go/quic-go => github.com/quic-go/quic-go v0.32.0
+
+replace go.uber.org/multierr => go.uber.org/multierr v1.8.0

--- a/internal/configure/hosts/hc_get.go
+++ b/internal/configure/hosts/hc_get.go
@@ -85,7 +85,13 @@ func (hc *HostConfig) GetUser() string {
 	return user
 }
 
+func (hc *HostConfig) GetProtocol() string { return hc.getString(CONFIG_PROTOCOL) }
 func (hc *HostConfig) GetSSHConfig() *module.SSHConfig {
+
+	if hc.GetProtocol() != SSH_PROTOCOL {
+		return nil
+	}
+
 	hostname := hc.GetSSHHostname()
 	if len(hostname) == 0 {
 		hostname = hc.GetHostname()
@@ -103,3 +109,40 @@ func (hc *HostConfig) GetSSHConfig() *module.SSHConfig {
 		ConnectRetries:    curveadm.GlobalCurveAdmConfig.GetSSHRetries(),
 	}
 }
+
+func (hc *HostConfig) GetHTTPConfig() *module.HTTPConfig {
+
+	if hc.GetProtocol() != HTTP_PROTOCOL {
+		return nil
+	}
+
+	return &module.HTTPConfig{
+		Host: hc.GetHostname(),
+		Port: (uint)(hc.GetHTTPPort()),
+	}
+}
+
+func (hc *HostConfig) GetConnectConfig() *module.ConnectConfig {
+
+	hostname := hc.GetSSHHostname()
+	if len(hostname) == 0 {
+		hostname = hc.GetHostname()
+	}
+
+	return &module.ConnectConfig{
+		User:              hc.GetUser(),
+		Host:              hostname,
+		SSHPort:           (uint)(hc.GetSSHPort()),
+		HTTPPort:          (uint)(hc.GetHTTPPort()),
+		PrivateKeyPath:    hc.GetPrivateKeyFile(),
+		ForwardAgent:      hc.GetForwardAgent(),
+		BecomeMethod:      "sudo",
+		BecomeFlags:       "-iu",
+		BecomeUser:        hc.GetBecomeUser(),
+		ConnectTimeoutSec: curveadm.GlobalCurveAdmConfig.GetSSHTimeout(),
+		ConnectRetries:    curveadm.GlobalCurveAdmConfig.GetSSHRetries(),
+		Protocol:          hc.GetProtocol(),
+	}
+}
+
+func (hc *HostConfig) GetHTTPPort() int { return hc.getInt(CONFIG_HTTP_PORT) }

--- a/internal/configure/hosts/hc_item.go
+++ b/internal/configure/hosts/hc_item.go
@@ -32,7 +32,10 @@ import (
 )
 
 const (
-	DEFAULT_SSH_PORT = 22
+	DEFAULT_SSH_PORT  = 22
+	DEFAULT_HTTP_PORT = 8000
+	SSH_PROTOCOL      = "ssh"
+	HTTP_PROTOCOL     = "http"
 )
 
 var (
@@ -96,5 +99,19 @@ var (
 		comm.REQUIRE_STRING,
 		false,
 		nil,
+	)
+
+	CONFIG_PROTOCOL = itemset.Insert(
+		"protocol",
+		comm.REQUIRE_STRING,
+		false,
+		SSH_PROTOCOL,
+	)
+
+	CONFIG_HTTP_PORT = itemset.Insert(
+		"http_port",
+		comm.REQUIRE_POSITIVE_INTEGER,
+		false,
+		DEFAULT_HTTP_PORT,
 	)
 )

--- a/internal/configure/hosts/hosts.go
+++ b/internal/configure/hosts/hosts.go
@@ -32,6 +32,7 @@ import (
 	"github.com/opencurve/curveadm/internal/configure/os"
 	"github.com/opencurve/curveadm/internal/errno"
 	"github.com/opencurve/curveadm/internal/utils"
+	"github.com/opencurve/curveadm/pkg/module"
 	"github.com/spf13/viper"
 )
 
@@ -158,7 +159,7 @@ func (hc *HostConfig) Build() error {
 			F("hosts[%d].private_key_file = %s", hc.sequence, privateKeyFile)
 	}
 
-	if hc.GetForwardAgent() == false {
+	if hc.GetForwardAgent() == false && hc.GetProtocol() == module.SSH_PROTOCOL {
 		if !utils.PathExist(privateKeyFile) {
 			return errno.ERR_PRIVATE_KEY_FILE_NOT_EXIST.
 				F("%s: no such file", privateKeyFile)

--- a/internal/daemon/core/core.go
+++ b/internal/daemon/core/core.go
@@ -1,0 +1,71 @@
+/*
+*  Copyright (c) 2023 NetEase Inc.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+ */
+
+package core
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/opencurve/curveadm/internal/errno"
+	"github.com/opencurve/pigeon"
+)
+
+func Exit(r *pigeon.Request, err error) bool {
+	var status int
+	if err == nil {
+		status = 200
+		r.SendJSON(pigeon.JSON{
+			"errorCode": "0",
+			"errorMsg":  "success",
+		})
+	} else {
+		code := err.(*errno.ErrorCode)
+		if code.IsHttpErr() {
+			status = code.HttpCode()
+		} else {
+			status = 503
+		}
+		r.SendJSON(pigeon.JSON{
+			"errorCode": strconv.Itoa(code.GetCode()),
+			"errorMsg":  fmt.Sprintf("desc: %s; clue: %s", code.GetDescription(), code.GetClue()),
+		})
+	}
+	return r.Exit(status)
+}
+
+func Default(r *pigeon.Request) bool {
+	r.Logger().Warn("unupport request uri", pigeon.Field("uri", r.Uri))
+	return Exit(r, errno.ERR_UNSUPPORT_REQUEST_URI)
+}
+
+func ExitSuccessWithData(r *pigeon.Request, data interface{}) bool {
+	r.SendJSON(pigeon.JSON{
+		"data":      data,
+		"errorCode": "0",
+		"errorMsg":  "success",
+	})
+	return r.Exit(200)
+}
+
+func ExitFailWithData(r *pigeon.Request, data interface{}, message string) bool {
+	r.SendJSON(pigeon.JSON{
+		"errorCode": "503",
+		"errorMsg":  message,
+		"data":      data,
+	})
+	return r.Exit(503)
+}

--- a/internal/daemon/manager/bind.go
+++ b/internal/daemon/manager/bind.go
@@ -1,0 +1,82 @@
+/*
+*  Copyright (c) 2023 NetEase Inc.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+ */
+
+package manager
+
+import (
+	"mime/multipart"
+	"net/http"
+
+	"github.com/opencurve/pigeon"
+)
+
+var METHOD_REQUEST map[string]Request
+
+type (
+	HandlerFunc func(r *pigeon.Request, ctx *Context) bool
+
+	Context struct {
+		Data interface{}
+	}
+
+	Request struct {
+		httpMethod string
+		method     string
+		vType      interface{}
+		handler    HandlerFunc
+	}
+)
+
+func init() {
+	METHOD_REQUEST = map[string]Request{}
+	for _, request := range requests {
+		METHOD_REQUEST[request.method] = request
+	}
+}
+
+type DeployClusterCmdRequest struct {
+	Command string `json:"command" binding:"required"`
+}
+
+type DeployClusterUploadRequest struct {
+	FilePath string                `json:"filepath" form:"filepath" binding:"required"`
+	File     *multipart.FileHeader `form:"file" binding:"required"`
+}
+
+type DeployClusterDownloadRequest struct {
+	FilePath string `json:"filepath" form:"filepath" binding:"required"`
+}
+
+var requests = []Request{
+	{
+		http.MethodPost,
+		"cluster.deploy.cmd",
+		DeployClusterCmdRequest{},
+		DeployClusterCmd,
+	},
+	{
+		http.MethodPost,
+		"cluster.deploy.upload",
+		DeployClusterUploadRequest{},
+		DeployClusterUpload,
+	},
+	{
+		http.MethodGet,
+		"cluster.deploy.download",
+		DeployClusterDownloadRequest{},
+		DeployClusterDownload,
+	},
+}

--- a/internal/daemon/manager/entrypoint.go
+++ b/internal/daemon/manager/entrypoint.go
@@ -1,0 +1,50 @@
+/*
+*  Copyright (c) 2023 NetEase Inc.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+ */
+
+package manager
+
+import (
+	"reflect"
+
+	"github.com/mcuadros/go-defaults"
+	"github.com/opencurve/curveadm/internal/daemon/core"
+	"github.com/opencurve/curveadm/internal/errno"
+	"github.com/opencurve/pigeon"
+)
+
+func Entrypoint(r *pigeon.Request) bool {
+	if r.Method != pigeon.HTTP_METHOD_GET &&
+		r.Method != pigeon.HTTP_METHOD_POST {
+		return core.Exit(r, errno.ERR_UNSUPPORT_HTTP_METHOD)
+	}
+
+	request, ok := METHOD_REQUEST[r.Args["method"]]
+	if !ok {
+		return core.Exit(r, errno.ERR_UNSUPPORT_METHOD_ARGUMENT)
+	} else if request.httpMethod != r.Method {
+		return core.Exit(r, errno.ERR_HTTP_METHOD_MISMATCHED)
+	}
+
+	vType := reflect.TypeOf(request.vType)
+	data := reflect.New(vType).Interface()
+	if err := r.BindBody(data); err != nil {
+		r.Logger().Error("bad request form param",
+			pigeon.Field("error", err))
+		return core.Exit(r, errno.ERR_BAD_REQUEST_FORM_PARAM)
+	}
+	defaults.SetDefaults(data)
+	return request.handler(r, &Context{data})
+}

--- a/internal/daemon/manager/manager.go
+++ b/internal/daemon/manager/manager.go
@@ -1,0 +1,71 @@
+/*
+*  Copyright (c) 2023 NetEase Inc.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+ */
+
+package manager
+
+import (
+	"io"
+	"os/exec"
+
+	"github.com/opencurve/curveadm/internal/daemon/core"
+	"github.com/opencurve/curveadm/internal/utils"
+	"github.com/opencurve/pigeon"
+)
+
+func DeployClusterCmd(r *pigeon.Request, ctx *Context) bool {
+	data := ctx.Data.(*DeployClusterCmdRequest)
+	r.Logger().Info("DeployClusterCmd", pigeon.Field("command", data.Command))
+	cmd := exec.Command("/bin/bash", "-c", data.Command)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		r.Logger().Warn("DeployClusterCmd failed when execute command",
+			pigeon.Field("error", err))
+		return core.ExitFailWithData(r, string(out), string(out))
+	}
+	r.Logger().Info("DeployClusterCmd", pigeon.Field("result", out))
+	return core.ExitSuccessWithData(r, string(out))
+}
+
+func DeployClusterUpload(r *pigeon.Request, ctx *Context) bool {
+	data := ctx.Data.(*DeployClusterUploadRequest)
+	r.Logger().Info("DeployClusterUpload", pigeon.Field("file", data.FilePath))
+	mf, err := data.File.Open()
+	if err != nil {
+		r.Logger().Warn("DeployClusterUpload failed when open file",
+			pigeon.Field("error", err))
+		return core.ExitFailWithData(r, err.Error(), err.Error())
+	}
+	defer mf.Close()
+	content, err := io.ReadAll(mf)
+	if err != nil {
+		r.Logger().Warn("DeployClusterUpload failed when read file",
+			pigeon.Field("error", err))
+		return core.ExitFailWithData(r, err.Error(), err.Error())
+	}
+	err = utils.WriteFile(data.FilePath, string(content), 0644)
+	if err != nil {
+		r.Logger().Warn("DeployClusterUpload failed when write file",
+			pigeon.Field("error", err))
+		return core.ExitFailWithData(r, err.Error(), err.Error())
+	}
+	return core.Exit(r, err)
+}
+
+func DeployClusterDownload(r *pigeon.Request, ctx *Context) bool {
+	data := ctx.Data.(*DeployClusterDownloadRequest)
+	r.Logger().Info("DeployClusterDownload", pigeon.Field("file", data.FilePath))
+	return r.SendFile(data.FilePath)
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1,0 +1,30 @@
+/*
+*  Copyright (c) 2023 NetEase Inc.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+ */
+
+package daemon
+
+import (
+	"github.com/opencurve/curveadm/internal/daemon/core"
+	"github.com/opencurve/curveadm/internal/daemon/manager"
+	"github.com/opencurve/pigeon"
+)
+
+func NewServer() *pigeon.HTTPServer {
+	server := pigeon.NewHTTPServer("curveadm")
+	server.Route("/", manager.Entrypoint)
+	server.DefaultRoute(core.Default)
+	return server
+}

--- a/internal/errno/errno.go
+++ b/internal/errno/errno.go
@@ -123,6 +123,14 @@ func (e *ErrorCode) Error() string {
 	return tui.PromptErrorCode(e.code, e.description, e.clue, gLogpath)
 }
 
+func (e *ErrorCode) IsHttpErr() bool {
+	return e.code/10000 == 70
+}
+
+func (e *ErrorCode) HttpCode() int {
+	return e.code % 1000
+}
+
 /*
  * 0xx: init curveadm
  *
@@ -253,8 +261,8 @@ var (
 	ERR_UNSUPPORT_CLEAN_ITEM           = EC(210005, "unsupport clean item")
 	ERR_NO_SERVICES_MATCHED            = EC(210006, "no services matched")
 	// TODO: please check pool set disk type
-	ERR_INVALID_DISK_TYPE = EC(210007, "poolset disk type must be lowercase and can only be one of ssd, hdd and nvme")
-
+	ERR_INVALID_DISK_TYPE     = EC(210007, "poolset disk type must be lowercase and can only be one of ssd, hdd and nvme")
+	ERR_UNSUPPORT_DEPLOY_TYPE = EC(210008, "unknown deploy type")
 	// 220: commad options (client common)
 	ERR_UNSUPPORT_CLIENT_KIND = EC(220000, "unsupport client kind")
 	// 221: command options (client/bs)
@@ -447,7 +455,8 @@ var (
 	ERR_METASERVER_REQUIRES_3_HOSTS       = EC(503009, "metaserver requires at least 3 hosts to distrubute zones")
 
 	// 510: checker (ssh)
-	ERR_SSH_CONNECT_FAILED = EC(510000, "SSH connect failed")
+	ERR_SSH_CONNECT_FAILED  = EC(510000, "SSH connect failed")
+	ERR_HTTP_CONNECT_FAILED = EC(510001, "HTTP connect failed")
 
 	// 520: checker (permission)
 	ERR_USER_NOT_FOUND                                     = EC(520000, "user not found")
@@ -548,6 +557,13 @@ var (
 
 	// 690: execuetr task (others)
 	ERR_START_CRONTAB_IN_CONTAINER_FAILED = EC(690000, "start crontab in container failed")
+
+	// 70: http service
+	ERR_UNSUPPORT_REQUEST_URI     = EC(701400, "unsupport request uri")
+	ERR_UNSUPPORT_METHOD_ARGUMENT = EC(702400, "unsupport method argument")
+	ERR_HTTP_METHOD_MISMATCHED    = EC(703400, "http method mismatch")
+	ERR_BAD_REQUEST_FORM_PARAM    = EC(704400, "bad request form param")
+	ERR_UNSUPPORT_HTTP_METHOD     = EC(705405, "unsupport http method")
 
 	// 900: others
 	ERR_CANCEL_OPERATION = EC(CODE_CANCEL_OPERATION, "cancel operation")

--- a/internal/task/context/context.go
+++ b/internal/task/context/context.go
@@ -29,27 +29,27 @@ import (
 )
 
 type Context struct {
-	sshClient *module.SSHClient
-	module    *module.Module
-	register  *Register
+	remoteClient module.RemoteClient
+	module       *module.Module
+	register     *Register
 }
 
-func NewContext(sshClient *module.SSHClient) (*Context, error) {
+func NewContext(remoteClient module.RemoteClient) (*Context, error) {
 	return &Context{
-		sshClient: sshClient,
-		module:    module.NewModule(sshClient),
-		register:  NewRegister(),
+		remoteClient: remoteClient,
+		module:       module.NewModule(remoteClient),
+		register:     NewRegister(),
 	}, nil
 }
 
 func (ctx *Context) Close() {
-	if ctx.sshClient != nil {
-		ctx.sshClient.Client().Close()
+	if ctx.remoteClient != nil {
+		ctx.remoteClient.Close()
 	}
 }
 
-func (ctx *Context) SSHClient() *module.SSHClient {
-	return ctx.sshClient
+func (ctx *Context) RemoteClient() module.RemoteClient {
+	return ctx.remoteClient
 }
 
 func (ctx *Context) Module() *module.Module {

--- a/internal/task/step/shell.go
+++ b/internal/task/step/shell.go
@@ -607,18 +607,9 @@ func (s *Scp) Execute(ctx *context.Context) error {
 		return errno.ERR_WRITE_FILE_FAILED.E(err)
 	}
 
-	config := ctx.SSHClient().Config()
-	cmd := ctx.Module().Shell().Scp(localPath, config.User, config.Host, s.RemotePath)
-	cmd.AddOption("-P %d", config.Port)
-	if !config.ForwardAgent {
-		cmd.AddOption("-i %s", config.PrivateKeyPath)
-	}
+	err = ctx.Module().File().Upload(localPath, s.RemotePath)
 
-	options := s.ExecOptions
-	options.ExecWithSudo = false
-	options.ExecInLocal = true
-	out, err := cmd.Execute(options)
-	return PostHandle(nil, nil, out, err, errno.ERR_SECURE_COPY_FILE_TO_REMOTE_FAILED)
+	return PostHandle(nil, nil, "", err, errno.ERR_SECURE_COPY_FILE_TO_REMOTE_FAILED)
 }
 
 func (s *Command) Execute(ctx *context.Context) error {

--- a/internal/task/task/bs/add_target.go
+++ b/internal/task/task/bs/add_target.go
@@ -52,7 +52,7 @@ func NewAddTargetTask(curveadm *cli.CurveAdm, cc *configure.ClientConfig) (*task
 	}
 
 	subname := fmt.Sprintf("host=%s volume=%s", options.Host, volume)
-	t := task.NewTask("Add Target", subname, hc.GetSSHConfig())
+	t := task.NewTask("Add Target", subname, hc.GetConnectConfig())
 
 	// add step
 	var output string

--- a/internal/task/task/bs/balance_leader.go
+++ b/internal/task/task/bs/balance_leader.go
@@ -48,7 +48,7 @@ func NewBalanceTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (*task.Ta
 
 	subname := fmt.Sprintf("host=%s role=%s containerId=%s",
 		dc.GetHost(), dc.GetRole(), tui.TrimContainerId(containerId))
-	t := task.NewTask("Balance Leader", subname, hc.GetSSHConfig())
+	t := task.NewTask("Balance Leader", subname, hc.GetConnectConfig())
 
 	// add step
 	t.AddStep(&step.ContainerExec{

--- a/internal/task/task/bs/create_volume.go
+++ b/internal/task/task/bs/create_volume.go
@@ -106,7 +106,7 @@ func NewCreateVolumeTask(curveadm *cli.CurveAdm, cc *configure.ClientConfig) (*t
 	}
 
 	subname := fmt.Sprintf("hostname=%s image=%s", hc.GetHostname(), cc.GetContainerImage())
-	t := task.NewTask("Create Volume", subname, hc.GetSSHConfig())
+	t := task.NewTask("Create Volume", subname, hc.GetConnectConfig())
 
 	// add step
 	var out string

--- a/internal/task/task/bs/delete_target.go
+++ b/internal/task/task/bs/delete_target.go
@@ -58,7 +58,7 @@ func NewDeleteTargetTask(curveadm *cli.CurveAdm, cc *client.ClientConfig) (*task
 	}
 
 	subname := fmt.Sprintf("hostname=%s tid=%s", hc.GetHostname(), options.Tid)
-	t := task.NewTask("Delete Target", subname, hc.GetSSHConfig())
+	t := task.NewTask("Delete Target", subname, hc.GetConnectConfig())
 
 	// add step
 	var output string

--- a/internal/task/task/bs/detect_release.go
+++ b/internal/task/task/bs/detect_release.go
@@ -75,7 +75,7 @@ func NewDetectOSReleaseTask(curveadm *cli.CurveAdm, v interface{}) (*task.Task, 
 	var success bool
 	var out string
 	subname := fmt.Sprintf("host=%s", host)
-	t := task.NewTask("Detect OS Release", subname, hc.GetSSHConfig())
+	t := task.NewTask("Detect OS Release", subname, hc.GetConnectConfig())
 
 	// add step to task
 	t.AddStep(&step.Cat{

--- a/internal/task/task/bs/format.go
+++ b/internal/task/task/bs/format.go
@@ -182,7 +182,7 @@ func NewFormatChunkfilePoolTask(curveadm *cli.CurveAdm, fc *configure.FormatConf
 	chunkSize := fc.GetChunkSize()
 	subname := fmt.Sprintf("host=%s device=%s mountPoint=%s usage=%d%%",
 		fc.GetHost(), device, mountPoint, usagePercent)
-	t := task.NewTask("Start Format Chunkfile Pool", subname, hc.GetSSHConfig())
+	t := task.NewTask("Start Format Chunkfile Pool", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var output, containerId, oldUUID string

--- a/internal/task/task/bs/format_status.go
+++ b/internal/task/task/bs/format_status.go
@@ -26,10 +26,10 @@ import (
 	"fmt"
 	"strings"
 
-	comm "github.com/opencurve/curveadm/internal/common"
-	"github.com/opencurve/curveadm/internal/errno"
 	"github.com/opencurve/curveadm/cli/cli"
+	comm "github.com/opencurve/curveadm/internal/common"
 	"github.com/opencurve/curveadm/internal/configure"
+	"github.com/opencurve/curveadm/internal/errno"
 	"github.com/opencurve/curveadm/internal/task/context"
 	"github.com/opencurve/curveadm/internal/task/step"
 	"github.com/opencurve/curveadm/internal/task/task"
@@ -122,7 +122,7 @@ func NewGetFormatStatusTask(curveadm *cli.CurveAdm, fc *configure.FormatConfig) 
 	// new task
 	device := fc.GetDevice()
 	subname := fmt.Sprintf("host=%s device=%s", fc.GetHost(), fc.GetDevice())
-	t := task.NewTask("Get Format Status", subname, hc.GetSSHConfig())
+	t := task.NewTask("Get Format Status", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var deviceUsage, containerStatus string

--- a/internal/task/task/bs/format_stop.go
+++ b/internal/task/task/bs/format_stop.go
@@ -79,7 +79,7 @@ func NewStopFormatTask(curveadm *cli.CurveAdm, fc *configure.FormatConfig) (*tas
 	containerName := device2ContainerName(device)
 	subname := fmt.Sprintf("host=%s device=%s mountPoint=%s containerName=%s",
 		fc.GetHost(), device, mountPoint, containerName)
-	t := task.NewTask("Stop Format Chunkfile Pool", subname, hc.GetSSHConfig())
+	t := task.NewTask("Stop Format Chunkfile Pool", subname, hc.GetConnectConfig())
 
 	var oldContainerId string
 	var oldUUID string

--- a/internal/task/task/bs/install_polarfs.go
+++ b/internal/task/task/bs/install_polarfs.go
@@ -104,7 +104,7 @@ func NewInstallPolarFSTask(curveadm *cli.CurveAdm, cc *configure.ClientConfig) (
 	// new task
 	release := getRelease(curveadm)
 	subname := fmt.Sprintf("host=%s release=%s", host, release)
-	t := task.NewTask("Install PolarFS", subname, hc.GetSSHConfig())
+	t := task.NewTask("Install PolarFS", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var input, output string

--- a/internal/task/task/bs/list_targets.go
+++ b/internal/task/task/bs/list_targets.go
@@ -119,7 +119,7 @@ func NewListTargetsTask(curveadm *cli.CurveAdm, v interface{}) (*task.Task, erro
 	}
 
 	subname := fmt.Sprintf("host=%s", hc.GetHostname())
-	t := task.NewTask("List Targets", subname, hc.GetSSHConfig())
+	t := task.NewTask("List Targets", subname, hc.GetConnectConfig())
 
 	// add step
 	var output string

--- a/internal/task/task/bs/map.go
+++ b/internal/task/task/bs/map.go
@@ -79,7 +79,7 @@ func NewMapTask(curveadm *cli.CurveAdm, cc *configure.ClientConfig) (*task.Task,
 	}
 
 	subname := fmt.Sprintf("hostname=%s volume=%s:%s", hc.GetHostname(), options.User, options.Volume)
-	t := task.NewTask("Map Volume", subname, hc.GetSSHConfig())
+	t := task.NewTask("Map Volume", subname, hc.GetConnectConfig())
 
 	// add step
 	var out string

--- a/internal/task/task/bs/start_nebd.go
+++ b/internal/task/task/bs/start_nebd.go
@@ -154,7 +154,7 @@ func NewStartNEBDServiceTask(curveadm *cli.CurveAdm, cc *configure.ClientConfig)
 	}
 
 	subname := fmt.Sprintf("hostname=%s image=%s", hc.GetHostname(), cc.GetContainerImage())
-	t := task.NewTask("Start NEBD Service", subname, hc.GetSSHConfig())
+	t := task.NewTask("Start NEBD Service", subname, hc.GetConnectConfig())
 
 	// add step
 	var containerId, out string

--- a/internal/task/task/bs/start_tgtd.go
+++ b/internal/task/task/bs/start_tgtd.go
@@ -66,7 +66,7 @@ func NewStartTargetDaemonTask(curveadm *cli.CurveAdm, cc *configure.ClientConfig
 
 	// new task
 	subname := fmt.Sprintf("host=%s image=%s", options.Host, cc.GetContainerImage())
-	t := task.NewTask("Start Target Daemon", subname, hc.GetSSHConfig())
+	t := task.NewTask("Start Target Daemon", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var status, containerId, out string

--- a/internal/task/task/bs/stop_tgtd.go
+++ b/internal/task/task/bs/stop_tgtd.go
@@ -50,7 +50,7 @@ func NewStopTargetDaemonTask(curveadm *cli.CurveAdm, v interface{}) (*task.Task,
 
 	// new task
 	subname := fmt.Sprintf("host=%s", options.Host)
-	t := task.NewTask("Stop Target Daemon", subname, hc.GetSSHConfig())
+	t := task.NewTask("Stop Target Daemon", subname, hc.GetConnectConfig())
 
 	// add step
 	var containerId string

--- a/internal/task/task/bs/uninstall_polarfs.go
+++ b/internal/task/task/bs/uninstall_polarfs.go
@@ -77,7 +77,7 @@ func NewUninstallPolarFSTask(curveadm *cli.CurveAdm, v interface{}) (*task.Task,
 	// new task
 	release := getRelease(curveadm)
 	subname := fmt.Sprintf("host=%s release=%s", host, release)
-	t := task.NewTask("Uninstall PolarFS", subname, hc.GetSSHConfig())
+	t := task.NewTask("Uninstall PolarFS", subname, hc.GetConnectConfig())
 
 	// add step to task
 	t.AddStep(&step.RemoveFile{

--- a/internal/task/task/bs/unmap.go
+++ b/internal/task/task/bs/unmap.go
@@ -144,7 +144,7 @@ func NewUnmapTask(curveadm *cli.CurveAdm, v interface{}) (*task.Task, error) {
 
 	subname := fmt.Sprintf("hostname=%s volume=%s:%s containerId=%s",
 		hc.GetHostname(), options.User, options.Volume, tui.TrimContainerId(containerId))
-	t := task.NewTask("Unmap Volume", subname, hc.GetSSHConfig())
+	t := task.NewTask("Unmap Volume", subname, hc.GetConnectConfig())
 
 	// add step
 	var output string

--- a/internal/task/task/checker/date.go
+++ b/internal/task/task/checker/date.go
@@ -87,7 +87,7 @@ func NewGetHostDate(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (*task.Ta
 	}
 
 	subname := fmt.Sprintf("host=%s start=%d", dc.GetHost(), time.Now().Unix())
-	t := task.NewTask("Get Host Date <date>", subname, hc.GetSSHConfig())
+	t := task.NewTask("Get Host Date <date>", subname, hc.GetConnectConfig())
 
 	var start int64
 	var out string

--- a/internal/task/task/checker/kernel.go
+++ b/internal/task/task/checker/kernel.go
@@ -106,7 +106,7 @@ func NewCheckKernelVersionTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig
 	// new task
 	subname := fmt.Sprintf("host=%s role=%s require=(>=%s)",
 		dc.GetHost(), dc.GetRole(), CHUNKSERVER_LEAST_KERNEL_VERSION)
-	t := task.NewTask("Check Kernel Version <kernel>", subname, hc.GetSSHConfig())
+	t := task.NewTask("Check Kernel Version <kernel>", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var out string
@@ -132,7 +132,7 @@ func NewCheckKernelModuleTask(curveadm *cli.CurveAdm, cc *configure.ClientConfig
 	// new task
 	name := curveadm.MemStorage().Get(comm.KEY_CHECK_KERNEL_MODULE_NAME).(string)
 	subname := fmt.Sprintf("host=%s module=%s", host, name)
-	t := task.NewTask("Check Kernel Module", subname, hc.GetSSHConfig())
+	t := task.NewTask("Check Kernel Module", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var out string

--- a/internal/task/task/checker/network.go
+++ b/internal/task/task/checker/network.go
@@ -134,7 +134,7 @@ func NewCheckPortInUseTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (*
 	addresses := getServiceListenAddresses(dc)
 	subname := fmt.Sprintf("host=%s role=%s ports={%s}",
 		dc.GetHost(), dc.GetRole(), joinPorts(dc, addresses))
-	t := task.NewTask("Check Port In Use <network>", subname, hc.GetSSHConfig())
+	t := task.NewTask("Check Port In Use <network>", subname, hc.GetConnectConfig())
 
 	var containerId, out string
 	var success bool
@@ -203,7 +203,7 @@ func NewCheckDestinationReachableTask(curveadm *cli.CurveAdm, dc *topology.Deplo
 	addresses := unique(getServiceConnectAddress(dc, dcs))
 	subname := fmt.Sprintf("host=%s role=%s ping={%s}",
 		dc.GetHost(), dc.GetRole(), tui.TrimAddress(strings.Join(addresses, ",")))
-	t := task.NewTask("Check Destination Reachable <network>", subname, hc.GetSSHConfig())
+	t := task.NewTask("Check Destination Reachable <network>", subname, hc.GetConnectConfig())
 
 	var out string
 	var success bool
@@ -258,7 +258,7 @@ func NewStartHTTPServerTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (
 	addresses := getServiceListenAddresses(dc)
 	subname := fmt.Sprintf("host=%s role=%s ports={%s}",
 		dc.GetHost(), dc.GetRole(), joinPorts(dc, addresses))
-	t := task.NewTask("Start Mock HTTP Server <network>", subname, hc.GetSSHConfig())
+	t := task.NewTask("Start Mock HTTP Server <network>", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var containerId, out string
@@ -329,7 +329,7 @@ func NewCheckNetworkFirewallTask(curveadm *cli.CurveAdm, dc *topology.DeployConf
 
 	// add task
 	subname := fmt.Sprintf("host=%s role=%s", dc.GetHost(), dc.GetRole())
-	t := task.NewTask("Check Network Firewall <network>", subname, hc.GetSSHConfig())
+	t := task.NewTask("Check Network Firewall <network>", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var out string
@@ -395,7 +395,7 @@ func NewCleanEnvironmentTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) 
 
 	// new task
 	subname := fmt.Sprintf("host=%s role=%s", dc.GetHost(), dc.GetRole())
-	t := task.NewTask("Clean Precheck Environment", subname, hc.GetSSHConfig())
+	t := task.NewTask("Clean Precheck Environment", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var out string

--- a/internal/task/task/checker/permission.go
+++ b/internal/task/task/checker/permission.go
@@ -119,7 +119,7 @@ func NewCheckPermissionTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (
 
 	// new task
 	subname := fmt.Sprintf("host=%s role=%s", dc.GetHost(), dc.GetRole())
-	t := task.NewTask("Check Permission <permission>", subname, hc.GetSSHConfig())
+	t := task.NewTask("Check Permission <permission>", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var out, hostname string
@@ -145,7 +145,7 @@ func NewCheckPermissionTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (
 	t.AddStep(&step.Ping{
 		Destination: &hostname,
 		Count:       1,
-		Timeout: 1,
+		Timeout:     1,
 		Success:     &success,
 		ExecOptions: curveadm.ExecOptions(),
 	})

--- a/internal/task/task/checker/service.go
+++ b/internal/task/task/checker/service.go
@@ -138,7 +138,7 @@ func NewCheckChunkfilePoolTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig
 	}
 
 	subname := fmt.Sprintf("host=%s role=%s", dc.GetHost(), dc.GetRole())
-	t := task.NewTask("Check Chunkfile Pool <service>", subname, hc.GetSSHConfig())
+	t := task.NewTask("Check Chunkfile Pool <service>", subname, hc.GetConnectConfig())
 
 	t.AddStep(&step2CheckChunkfilePool{
 		dc:          dc,
@@ -171,7 +171,7 @@ func NewCheckMdsAddressTask(curveadm *cli.CurveAdm, cc *configure.ClientConfig) 
 
 	address := cc.GetClusterMDSAddr()
 	subname := fmt.Sprintf("host=%s address=%s", host, address)
-	t := task.NewTask("Check MDS Address", subname, hc.GetSSHConfig())
+	t := task.NewTask("Check MDS Address", subname, hc.GetConnectConfig())
 
 	return t, nil
 }

--- a/internal/task/task/checker/ssh.go
+++ b/internal/task/task/checker/ssh.go
@@ -35,6 +35,7 @@ import (
 	"github.com/opencurve/curveadm/internal/task/step"
 	"github.com/opencurve/curveadm/internal/task/task"
 	"github.com/opencurve/curveadm/internal/utils"
+	"github.com/opencurve/curveadm/pkg/module"
 )
 
 const (
@@ -51,7 +52,7 @@ func doNothing() step.LambdaType {
 func checkHost(hc *hosts.HostConfig) step.LambdaType {
 	return func(ctx *context.Context) error {
 		privateKeyFile := hc.GetPrivateKeyFile()
-		if hc.GetForwardAgent() == false {
+		if hc.GetForwardAgent() == false && hc.GetProtocol() == module.SSH_PROTOCOL {
 			if !utils.PathExist(privateKeyFile) {
 				return errno.ERR_PRIVATE_KEY_FILE_NOT_EXIST.
 					F("%s: no such file", privateKeyFile)
@@ -73,7 +74,7 @@ func NewCheckSSHConnectTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (
 	// new task
 	method := utils.Choose(hc.GetForwardAgent(), "forwardAgent", "privateKey")
 	subname := fmt.Sprintf("host=%s method=%s", dc.GetHost(), method)
-	t := task.NewTask("Check SSH Connect <ssh>", subname, hc.GetSSHConfig())
+	t := task.NewTask("Check SSH Connect <ssh>", subname, hc.GetConnectConfig())
 
 	// add step to task
 	t.AddStep(&step.Lambda{

--- a/internal/task/task/common/backup_etcd.go
+++ b/internal/task/task/common/backup_etcd.go
@@ -57,7 +57,7 @@ func NewBackupEtcdDataTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (*
 
 	subname := fmt.Sprintf("host=%s role=%s containerId=%s",
 		dc.GetHost(), dc.GetRole(), tui.TrimContainerId(containerId))
-	t := task.NewTask("Backup Etcd Data", subname, hc.GetSSHConfig())
+	t := task.NewTask("Backup Etcd Data", subname, hc.GetConnectConfig())
 
 	t.AddStep(&step.ContainerExec{
 		ContainerId: &containerId,

--- a/internal/task/task/common/clean_service.go
+++ b/internal/task/task/common/clean_service.go
@@ -149,7 +149,7 @@ func NewCleanServiceTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (*ta
 	recycle := curveadm.MemStorage().Get(comm.KEY_CLEAN_BY_RECYCLE).(bool)
 	subname := fmt.Sprintf("host=%s role=%s containerId=%s clean=%s",
 		dc.GetHost(), dc.GetRole(), tui.TrimContainerId(containerId), strings.Join(only, ","))
-	t := task.NewTask("Clean Service", subname, hc.GetSSHConfig())
+	t := task.NewTask("Clean Service", subname, hc.GetConnectConfig())
 
 	// add step to task
 	clean := utils.Slice2Map(only)

--- a/internal/task/task/common/client_status.go
+++ b/internal/task/task/common/client_status.go
@@ -164,7 +164,7 @@ func NewGetClientStatusTask(curveadm *cli.CurveAdm, v interface{}) (*task.Task, 
 	containerId := client.ContainerId
 	subname := fmt.Sprintf("host=%s kind=%s containerId=%s",
 		hc.GetHost(), client.Kind, tui.TrimContainerId(containerId))
-	t := task.NewTask("Get Client Status", subname, hc.GetSSHConfig())
+	t := task.NewTask("Get Client Status", subname, hc.GetConnectConfig())
 
 	// add step
 	var status string

--- a/internal/task/task/common/collect_client.go
+++ b/internal/task/task/common/collect_client.go
@@ -47,7 +47,7 @@ func NewCollectClientTask(curveadm *cli.CurveAdm, v interface{}) (*task.Task, er
 	containerId := client.ContainerId
 	subname := fmt.Sprintf("host=%s kind=%s containerId=%s",
 		hc.GetHost(), client.Kind, tui.TrimContainerId(containerId))
-	t := task.NewTask("Collect Client", subname, hc.GetSSHConfig())
+	t := task.NewTask("Collect Client", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var out string

--- a/internal/task/task/common/collect_service.go
+++ b/internal/task/task/common/collect_service.go
@@ -93,7 +93,7 @@ func NewCollectServiceTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (*
 	// new task
 	subname := fmt.Sprintf("host=%s role=%s containerId=%s",
 		dc.GetHost(), dc.GetRole(), tui.TrimContainerId(containerId))
-	t := task.NewTask("Collect Service", subname, hc.GetSSHConfig())
+	t := task.NewTask("Collect Service", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var out string

--- a/internal/task/task/common/create_container.go
+++ b/internal/task/task/common/create_container.go
@@ -214,7 +214,7 @@ func NewCreateContainerTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (
 
 	// new task
 	subname := fmt.Sprintf("host=%s role=%s", dc.GetHost(), dc.GetRole())
-	t := task.NewTask("Create Container", subname, hc.GetSSHConfig())
+	t := task.NewTask("Create Container", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var oldContainerId, containerId string

--- a/internal/task/task/common/create_pool.go
+++ b/internal/task/task/common/create_pool.go
@@ -200,7 +200,7 @@ func NewCreateTopologyTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (*
 		"Create Logical Pool", "Create Physical Pool")
 	subname := fmt.Sprintf("host=%s role=%s containerId=%s",
 		dc.GetHost(), dc.GetRole(), tui.TrimContainerId(containerId))
-	t := task.NewTask(name, subname, hc.GetSSHConfig())
+	t := task.NewTask(name, subname, hc.GetConnectConfig())
 
 	// add step to task
 	var success bool

--- a/internal/task/task/common/etcd_auth_enable.go
+++ b/internal/task/task/common/etcd_auth_enable.go
@@ -63,7 +63,7 @@ func NewEnableEtcdAuthTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (*
 	// new task
 	subname := fmt.Sprintf("host=%s role=%s containerId=%s",
 		dc.GetHost(), dc.GetRole(), tui.TrimContainerId(containerId))
-	t := task.NewTask("Enable Etcd Auth", subname, hc.GetSSHConfig())
+	t := task.NewTask("Enable Etcd Auth", subname, hc.GetConnectConfig())
 
 	script := scripts.ENABLE_ETCD_AUTH
 	layout := dc.GetProjectLayout()

--- a/internal/task/task/common/install_client.go
+++ b/internal/task/task/common/install_client.go
@@ -142,7 +142,7 @@ func NewInstallClientTask(curveadm *cli.CurveAdm, cc *configure.ClientConfig) (*
 	release := getRelease(curveadm)
 	subname := fmt.Sprintf("host=%s release=%s", host, release)
 	name := utils.Choose(kind == KIND_CURVEBS, "CurveBS", "CurveFS")
-	t := task.NewTask(fmt.Sprintf("Install %s Client", name), subname, hc.GetSSHConfig())
+	t := task.NewTask(fmt.Sprintf("Install %s Client", name), subname, hc.GetConnectConfig())
 
 	// add step to task
 	var input, output string

--- a/internal/task/task/common/pull_image.go
+++ b/internal/task/task/common/pull_image.go
@@ -41,7 +41,7 @@ func NewPullImageTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (*task.
 
 	// new task
 	subname := fmt.Sprintf("host=%s image=%s", dc.GetHost(), dc.GetContainerImage())
-	t := task.NewTask("Pull Image", subname, hc.GetSSHConfig())
+	t := task.NewTask("Pull Image", subname, hc.GetConnectConfig())
 
 	// add step to task
 	t.AddStep(&step.PullImage{

--- a/internal/task/task/common/restart_service.go
+++ b/internal/task/task/common/restart_service.go
@@ -71,7 +71,7 @@ func NewRestartServiceTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (*
 	// new task
 	subname := fmt.Sprintf("host=%s role=%s containerId=%s",
 		dc.GetHost(), dc.GetRole(), tui.TrimContainerId(containerId))
-	t := task.NewTask("Restart Service", subname, hc.GetSSHConfig())
+	t := task.NewTask("Restart Service", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var out string

--- a/internal/task/task/common/service_status.go
+++ b/internal/task/task/common/service_status.go
@@ -265,7 +265,7 @@ func NewGetServiceStatusTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) 
 	// new task
 	subname := fmt.Sprintf("host=%s role=%s containerId=%s",
 		dc.GetHost(), dc.GetRole(), tui.TrimContainerId(containerId))
-	t := task.NewTask("Get Service Status", subname, hc.GetSSHConfig())
+	t := task.NewTask("Get Service Status", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var status string

--- a/internal/task/task/common/start_service.go
+++ b/internal/task/task/common/start_service.go
@@ -89,7 +89,7 @@ func NewStartServiceTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (*ta
 	// new task
 	subname := fmt.Sprintf("host=%s role=%s containerId=%s",
 		dc.GetHost(), dc.GetRole(), tui.TrimContainerId(containerId))
-	t := task.NewTask("Start Service", subname, hc.GetSSHConfig())
+	t := task.NewTask("Start Service", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var out string

--- a/internal/task/task/common/stop_service.go
+++ b/internal/task/task/common/stop_service.go
@@ -73,7 +73,7 @@ func NewStopServiceTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (*tas
 	// new task
 	subname := fmt.Sprintf("host=%s role=%s containerId=%s",
 		dc.GetHost(), dc.GetRole(), tui.TrimContainerId(containerId))
-	t := task.NewTask("Stop Service", subname, hc.GetSSHConfig())
+	t := task.NewTask("Stop Service", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var out string

--- a/internal/task/task/common/sync_config.go
+++ b/internal/task/task/common/sync_config.go
@@ -103,7 +103,7 @@ func NewSyncConfigTask(curveadm *cli.CurveAdm, dc *topology.DeployConfig) (*task
 	// new task
 	subname := fmt.Sprintf("host=%s role=%s containerId=%s",
 		dc.GetHost(), dc.GetRole(), tui.TrimContainerId(containerId))
-	t := task.NewTask("Sync Config", subname, hc.GetSSHConfig())
+	t := task.NewTask("Sync Config", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var out string

--- a/internal/task/task/common/uninstall_client.go
+++ b/internal/task/task/common/uninstall_client.go
@@ -81,7 +81,7 @@ func NewUninstallClientTask(curveadm *cli.CurveAdm, v interface{}) (*task.Task, 
 	kind := curveadm.MemStorage().Get(comm.KEY_CLIENT_KIND).(string)
 	subname := fmt.Sprintf("host=%s release=%s kind=%s", host, release, kind)
 	name := utils.Choose(kind == KIND_CURVEBS, "CurveBS", "CurveFS")
-	t := task.NewTask(fmt.Sprintf("Uninstall %s Client", name), subname, hc.GetSSHConfig())
+	t := task.NewTask(fmt.Sprintf("Uninstall %s Client", name), subname, hc.GetConnectConfig())
 
 	// add step to task
 	t.AddPostStep(&step2UninstallPackage{

--- a/internal/task/task/common/update_topology.go
+++ b/internal/task/task/common/update_topology.go
@@ -27,10 +27,10 @@ package common
 import (
 	"github.com/opencurve/curveadm/cli/cli"
 	comm "github.com/opencurve/curveadm/internal/common"
+	"github.com/opencurve/curveadm/internal/errno"
 	"github.com/opencurve/curveadm/internal/task/context"
 	"github.com/opencurve/curveadm/internal/task/step"
 	"github.com/opencurve/curveadm/internal/task/task"
-	"github.com/opencurve/curveadm/internal/errno"
 )
 
 func updateTopology(curveadm *cli.CurveAdm) step.LambdaType {

--- a/internal/task/task/fs/mount.go
+++ b/internal/task/task/fs/mount.go
@@ -289,7 +289,7 @@ func NewMountFSTask(curveadm *cli.CurveAdm, cc *configure.ClientConfig) (*task.T
 	mountFSName := options.MountFSName
 	mountFSType := options.MountFSType
 	subname := fmt.Sprintf("mountFSName=%s mountFSType=%s mountPoint=%s", mountFSName, mountFSType, mountPoint)
-	t := task.NewTask("Mount FileSystem", subname, hc.GetSSHConfig())
+	t := task.NewTask("Mount FileSystem", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var containerId, out string

--- a/internal/task/task/fs/umount.go
+++ b/internal/task/task/fs/umount.go
@@ -131,7 +131,7 @@ func NewUmountFSTask(curveadm *cli.CurveAdm, v interface{}) (*task.Task, error) 
 	// new task
 	mountPoint := options.MountPoint
 	subname := fmt.Sprintf("host=%s mountPoint=%s", options.Host, mountPoint)
-	t := task.NewTask("Umount FileSystem", subname, hc.GetSSHConfig())
+	t := task.NewTask("Umount FileSystem", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var status string

--- a/internal/task/task/monitor/clean_container.go
+++ b/internal/task/task/monitor/clean_container.go
@@ -44,7 +44,7 @@ func NewCleanConfigContainerTask(curveadm *cli.CurveAdm, cfg *configure.MonitorC
 	if err != nil {
 		return nil, err
 	}
-	t := task.NewTask("Clean Config Container", "", hc.GetSSHConfig())
+	t := task.NewTask("Clean Config Container", "", hc.GetConnectConfig())
 	t.AddStep(&common.Step2CleanContainer{
 		ServiceId:   serviceId,
 		ContainerId: containerId,

--- a/internal/task/task/monitor/clean_service.go
+++ b/internal/task/task/monitor/clean_service.go
@@ -73,7 +73,7 @@ func NewCleanMonitorTask(curveadm *cli.CurveAdm, cfg *configure.MonitorConfig) (
 	only := curveadm.MemStorage().Get(comm.KEY_CLEAN_ITEMS).([]string)
 	subname := fmt.Sprintf("host=%s role=%s containerId=%s clean=%s",
 		cfg.GetHost(), cfg.GetRole(), tui.TrimContainerId(containerId), strings.Join(only, ","))
-	t := task.NewTask("Clean Monitor", subname, hc.GetSSHConfig())
+	t := task.NewTask("Clean Monitor", subname, hc.GetConnectConfig())
 
 	// add step to task
 	clean := utils.Slice2Map(only)

--- a/internal/task/task/monitor/create_container.go
+++ b/internal/task/task/monitor/create_container.go
@@ -120,7 +120,7 @@ func NewCreateContainerTask(curveadm *cli.CurveAdm, cfg *configure.MonitorConfig
 
 	// new task
 	subname := fmt.Sprintf("host=%s role=%s", host, cfg.GetRole())
-	t := task.NewTask("Create Container", subname, hc.GetSSHConfig())
+	t := task.NewTask("Create Container", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var oldContainerId, containerId string

--- a/internal/task/task/monitor/pull_image.go
+++ b/internal/task/task/monitor/pull_image.go
@@ -41,7 +41,7 @@ func NewPullImageTask(curveadm *cli.CurveAdm, cfg *configure.MonitorConfig) (*ta
 
 	// new task
 	subname := fmt.Sprintf("host=%s image=%s", host, image)
-	t := task.NewTask("Pull Image", subname, hc.GetSSHConfig())
+	t := task.NewTask("Pull Image", subname, hc.GetConnectConfig())
 	// add step to task
 	t.AddStep(&step.PullImage{
 		Image:       image,

--- a/internal/task/task/monitor/restart_service.go
+++ b/internal/task/task/monitor/restart_service.go
@@ -49,7 +49,7 @@ func NewRestartServiceTask(curveadm *cli.CurveAdm, cfg *configure.MonitorConfig)
 	// new task
 	subname := fmt.Sprintf("host=%s role=%s containerId=%s",
 		cfg.GetHost(), cfg.GetRole(), tui.TrimContainerId(containerId))
-	t := task.NewTask("Restart Monitor Service", subname, hc.GetSSHConfig())
+	t := task.NewTask("Restart Monitor Service", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var out string

--- a/internal/task/task/monitor/start_service.go
+++ b/internal/task/task/monitor/start_service.go
@@ -59,7 +59,7 @@ func NewStartServiceTask(curveadm *cli.CurveAdm, cfg *configure.MonitorConfig) (
 	// new task
 	subname := fmt.Sprintf("host=%s role=%s containerId=%s",
 		cfg.GetHost(), cfg.GetRole(), tui.TrimContainerId(containerId))
-	t := task.NewTask("Start Service", subname, hc.GetSSHConfig())
+	t := task.NewTask("Start Service", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var out string

--- a/internal/task/task/monitor/status_service.go
+++ b/internal/task/task/monitor/status_service.go
@@ -154,7 +154,7 @@ func NewGetMonitorStatusTask(curveadm *cli.CurveAdm, cfg *configure.MonitorConfi
 	// new task
 	subname := fmt.Sprintf("host=%s role=%s containerId=%s",
 		cfg.GetHost(), cfg.GetRole(), tui.TrimContainerId(containerId))
-	t := task.NewTask("Get Monitor Status", subname, hc.GetSSHConfig())
+	t := task.NewTask("Get Monitor Status", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var status string

--- a/internal/task/task/monitor/stop_service.go
+++ b/internal/task/task/monitor/stop_service.go
@@ -49,7 +49,7 @@ func NewStopServiceTask(curveadm *cli.CurveAdm, cfg *configure.MonitorConfig) (*
 	// new task
 	subname := fmt.Sprintf("host=%s role=%s containerId=%s",
 		cfg.GetHost(), cfg.GetRole(), tui.TrimContainerId(containerId))
-	t := task.NewTask("Stop Service", subname, hc.GetSSHConfig())
+	t := task.NewTask("Stop Service", subname, hc.GetConnectConfig())
 
 	// add step to task
 	var out string

--- a/internal/task/task/monitor/sync_config.go
+++ b/internal/task/task/monitor/sync_config.go
@@ -72,7 +72,7 @@ func NewSyncConfigTask(curveadm *cli.CurveAdm, cfg *configure.MonitorConfig) (*t
 	// new task
 	subname := fmt.Sprintf("host=%s role=%s containerId=%s",
 		cfg.GetHost(), cfg.GetRole(), tui.TrimContainerId(containerId))
-	t := task.NewTask("Sync Config", subname, hc.GetSSHConfig())
+	t := task.NewTask("Sync Config", subname, hc.GetConnectConfig())
 	// add step to task
 	var out string
 	t.AddStep(&step.ListContainers{ // gurantee container exist

--- a/internal/task/task/task.go
+++ b/internal/task/task/task.go
@@ -26,9 +26,7 @@ package task
 
 import (
 	"errors"
-
 	"github.com/google/uuid"
-	"github.com/opencurve/curveadm/internal/errno"
 	"github.com/opencurve/curveadm/internal/task/context"
 	"github.com/opencurve/curveadm/pkg/module"
 )
@@ -44,25 +42,25 @@ type (
 	}
 
 	Task struct {
-		tid       string // task id
-		ptid      string // parent task id
-		name      string
-		subname   string
-		steps     []Step
-		postSteps []Step
-		sshConfig *module.SSHConfig
-		context   context.Context
+		tid           string // task id
+		ptid          string // parent task id
+		name          string
+		subname       string
+		steps         []Step
+		postSteps     []Step
+		connectConfig *module.ConnectConfig
+		context       context.Context
 	}
 )
 
-func NewTask(name, subname string, sshConfig *module.SSHConfig) *Task {
+func NewTask(name, subname string, connectConfig *module.ConnectConfig) *Task {
 	tid := uuid.NewString()[:12]
 	return &Task{
-		tid:       tid,
-		ptid:      tid,
-		name:      name,
-		subname:   subname,
-		sshConfig: sshConfig,
+		tid:           tid,
+		ptid:          tid,
+		name:          name,
+		subname:       subname,
+		connectConfig: connectConfig,
 	}
 }
 
@@ -112,16 +110,12 @@ func (t *Task) executePost(ctx *context.Context) {
 }
 
 func (t *Task) Execute() error {
-	var sshClient *module.SSHClient
-	if t.sshConfig != nil {
-		client, err := module.NewSSHClient(*t.sshConfig)
-		if err != nil {
-			return errno.ERR_SSH_CONNECT_FAILED.E(err)
-		}
-		sshClient = client
+	remoteClient, err := module.NewRemoteClient(t.connectConfig)
+	if err != nil {
+		return err
 	}
 
-	ctx, err := context.NewContext(sshClient)
+	ctx, err := context.NewContext(remoteClient)
 	if err != nil {
 		return err
 	}

--- a/internal/tui/hosts.go
+++ b/internal/tui/hosts.go
@@ -45,6 +45,8 @@ func FormatHosts(hcs []*configure.HostConfig, verbose bool) string {
 		"Hostname",
 		"User",
 		"Port",
+		"Protocol",
+		"HTTP Port",
 		"Private Key File",
 		"Forward Agent",
 		"Become User",
@@ -60,8 +62,10 @@ func FormatHosts(hcs []*configure.HostConfig, verbose bool) string {
 
 		host := hc.GetHost()
 		hostname := hc.GetHostname()
+		protocol := hc.GetProtocol()
 		user := hc.GetUser()
 		port := strconv.Itoa(hc.GetSSHPort())
+		httpPort := strconv.Itoa(hc.GetHTTPPort())
 		forwardAgent := utils.Choose(hc.GetForwardAgent(), "Y", "N")
 		becomeUser := utils.Choose(len(hc.GetBecomeUser()) > 0, hc.GetBecomeUser(), "-")
 		labels := utils.Choose(len(hc.GetLabels()) > 0, strings.Join(hc.GetLabels(), ","), "-")
@@ -78,6 +82,8 @@ func FormatHosts(hcs []*configure.HostConfig, verbose bool) string {
 			hostname,
 			user,
 			port,
+			protocol,
+			httpPort,
 			privateKeyFile,
 			forwardAgent,
 			becomeUser,

--- a/pkg/module/docker_cli.go
+++ b/pkg/module/docker_cli.go
@@ -49,18 +49,18 @@ const (
 )
 
 type DockerCli struct {
-	sshClient *SSHClient
-	options   []string
-	tmpl      *template.Template
-	data      map[string]interface{}
+	options      []string
+	tmpl         *template.Template
+	data         map[string]interface{}
+	remoteClient RemoteClient
 }
 
-func NewDockerCli(sshClient *SSHClient) *DockerCli {
+func NewDockerCli(remoteClient RemoteClient) *DockerCli {
 	return &DockerCli{
-		sshClient: sshClient,
-		options:   []string{},
-		tmpl:      nil,
-		data:      map[string]interface{}{},
+		remoteClient: remoteClient,
+		options:      []string{},
+		tmpl:         nil,
+		data:         map[string]interface{}{},
 	}
 }
 
@@ -72,7 +72,7 @@ func (s *DockerCli) AddOption(format string, args ...interface{}) *DockerCli {
 func (cli *DockerCli) Execute(options ExecOptions) (string, error) {
 	cli.data["options"] = strings.Join(cli.options, " ")
 	cli.data["engine"] = options.ExecWithEngine
-	return execCommand(cli.sshClient, cli.tmpl, cli.data, options)
+	return execCommand(cli.remoteClient, cli.tmpl, cli.data, options)
 }
 
 func (cli *DockerCli) DockerInfo() *DockerCli {

--- a/pkg/module/file.go
+++ b/pkg/module/file.go
@@ -41,35 +41,36 @@ var (
 )
 
 type FileManager struct {
-	sshClient *SSHClient
+	remoteClient RemoteClient
 }
 
-func NewFileManager(sshClient *SSHClient) *FileManager {
-	return &FileManager{sshClient: sshClient}
+func NewFileManager(remoteClient RemoteClient) *FileManager {
+	return &FileManager{remoteClient: remoteClient}
 }
 
 func (f *FileManager) Upload(localPath, remotePath string) error {
-	if f.sshClient == nil {
+	if f.remoteClient == nil {
 		return ERR_UNREACHED
 	}
 
-	err := f.sshClient.Client().Upload(localPath, remotePath)
+	err := f.remoteClient.Upload(localPath, remotePath)
 	log.SwitchLevel(err)("UploadFile",
-		log.Field("remoteAddress", remoteAddr(f.sshClient)),
+		log.Field("remoteAddress", remoteAddr(f.remoteClient)),
 		log.Field("localPath", localPath),
 		log.Field("remotePath", remotePath),
-		log.Field("error", err))
+		log.Field("error", err),
+		log.Field("protocol", f.remoteClient.Protocol()))
 	return err
 }
 
 func (f *FileManager) Download(remotePath, localPath string) error {
-	if f.sshClient == nil {
+	if f.remoteClient == nil {
 		return ERR_UNREACHED
 	}
 
-	err := f.sshClient.Client().Download(remotePath, localPath)
+	err := f.remoteClient.Download(remotePath, localPath)
 	log.SwitchLevel(err)("DownloadFile",
-		log.Field("remoteAddress", remoteAddr(f.sshClient)),
+		log.Field("remoteAddress", remoteAddr(f.remoteClient)),
 		log.Field("remotePath", remotePath),
 		log.Field("localPath", localPath),
 		log.Field("error", err))

--- a/pkg/module/http.go
+++ b/pkg/module/http.go
@@ -1,0 +1,166 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package module
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+
+	log "github.com/opencurve/curveadm/pkg/log/glg"
+)
+
+const (
+	HTTP_PROTOCOL = "http"
+)
+
+type (
+	HTTPConfig struct {
+		Host string
+		Port uint
+	}
+
+	HttpClient struct {
+		config HTTPConfig
+		client *http.Client
+	}
+
+	HttpResult struct {
+		Data      string `json:"data"`
+		ErrorCode string `json:"errorCode"`
+		ErrorMsg  string `json:"errorMsg"`
+	}
+)
+
+func (client *HttpClient) Protocol() string {
+	return HTTP_PROTOCOL
+}
+
+func (client *HttpClient) WrapperCommand(command string, execInLocal bool) (wrapperCmd string) {
+	return command
+}
+
+func (client *HttpClient) RunCommand(ctx context.Context, command string) (out []byte, err error) {
+	data := make(map[string]interface{})
+	data["command"] = command
+	bytesData, _ := json.Marshal(data)
+
+	baseURL, _ := url.Parse(fmt.Sprintf("http://%s:%d", client.config.Host, client.config.Port))
+	params := url.Values{}
+	params.Add("method", "cluster.deploy.cmd")
+	baseURL.RawQuery = params.Encode()
+	resp, err := client.client.Post(baseURL.String(), "application/json", bytes.NewReader(bytesData))
+	if err != nil {
+		return
+	}
+	respData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+	result := &HttpResult{}
+	err = json.Unmarshal(respData, result)
+	if err != nil {
+		return
+	}
+
+	log.Info("http resp", log.Field("result", result))
+
+	if result.ErrorCode != "0" {
+		return []byte(result.Data), fmt.Errorf(result.ErrorMsg)
+	}
+
+	return []byte(result.Data), nil
+}
+
+func (client *HttpClient) RemoteAddr() (addr string) {
+	config := client.Config()
+	return fmt.Sprintf("%s:%d", config.Host, config.Port)
+}
+
+func (client *HttpClient) Upload(localPath string, remotePath string) (err error) {
+	bodyBuf := &bytes.Buffer{}
+	bodyWriter := multipart.NewWriter(bodyBuf)
+	fh, err := os.Open(localPath)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+	fileWriter, err := bodyWriter.CreateFormFile("file", localPath)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(fileWriter, fh)
+	if err != nil {
+		return err
+	}
+
+	baseURL, _ := url.Parse(fmt.Sprintf("http://%s:%d", client.config.Host, client.config.Port))
+	params := url.Values{}
+	params.Add("method", "cluster.deploy.upload")
+	baseURL.RawQuery = params.Encode()
+	boundary := "--boundary"
+	bodyWriter.SetBoundary(boundary)
+	bodyWriter.WriteField("filepath", remotePath)
+	bodyWriter.Close()
+	resp, err := client.client.Post(baseURL.String(), bodyWriter.FormDataContentType(), bodyBuf)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return err
+}
+
+func (client *HttpClient) Download(remotePath string, localPath string) (err error) {
+	baseURL, _ := url.Parse(fmt.Sprintf("http://%s:%d", client.config.Host, client.config.Port))
+	params := url.Values{}
+	params.Add("method", "cluster.deploy.download")
+	params.Add("filepath", remotePath)
+	baseURL.RawQuery = params.Encode()
+	resp, err := client.client.Get(baseURL.String())
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	localFile, err := os.Create(localPath)
+	if err != nil {
+		return
+	}
+	defer localFile.Close()
+	_, err = io.Copy(localFile, resp.Body)
+	return
+}
+
+func (client *HttpClient) Close() {
+
+}
+
+func (client *HttpClient) Config() HTTPConfig {
+	return client.config
+}
+
+func NewHTTPClient(config HTTPConfig) (*HttpClient, error) {
+	return &HttpClient{
+		config: config,
+		client: &http.Client{},
+	}, nil
+}

--- a/pkg/module/remote_client.go
+++ b/pkg/module/remote_client.go
@@ -1,0 +1,74 @@
+package module
+
+import (
+	"context"
+	"github.com/opencurve/curveadm/internal/errno"
+)
+
+type ConnectConfig struct {
+	User              string
+	Host              string
+	SSHPort           uint
+	HTTPPort          uint
+	ForwardAgent      bool // ForwardAgent > PrivateKeyPath > Password
+	BecomeMethod      string
+	BecomeFlags       string
+	BecomeUser        string
+	PrivateKeyPath    string
+	ConnectRetries    int
+	ConnectTimeoutSec int
+	Protocol          string
+}
+
+func (c *ConnectConfig) GetSSHConfig() *SSHConfig {
+	return &SSHConfig{
+		User:              c.User,
+		Host:              c.Host,
+		Port:              c.SSHPort,
+		ForwardAgent:      c.ForwardAgent,
+		BecomeMethod:      c.BecomeMethod,
+		BecomeFlags:       c.BecomeFlags,
+		BecomeUser:        c.BecomeUser,
+		PrivateKeyPath:    c.PrivateKeyPath,
+		ConnectRetries:    c.ConnectRetries,
+		ConnectTimeoutSec: c.ConnectTimeoutSec,
+	}
+}
+
+func (c *ConnectConfig) GetHTTPConfig() *HTTPConfig {
+	return &HTTPConfig{
+		Host: c.Host,
+		Port: c.HTTPPort,
+	}
+}
+
+type RemoteClient interface {
+	Protocol() string
+	WrapperCommand(command string, execInLocal bool) (wrapperCmd string)
+	RunCommand(ctx context.Context, command string) (out []byte, err error)
+	RemoteAddr() (addr string)
+	Upload(localPath string, remotePath string) (err error)
+	Download(remotePath string, localPath string) (err error)
+	Close()
+}
+
+func NewRemoteClient(cfg *ConnectConfig) (client RemoteClient, err error) {
+	if cfg == nil {
+		return
+	}
+
+	if cfg.Protocol == SSH_PROTOCOL {
+		client, err = NewSSHClient(*cfg.GetSSHConfig())
+		if err != nil {
+			return nil, errno.ERR_SSH_CONNECT_FAILED.E(err)
+		}
+		return client, nil
+	} else if cfg.Protocol == HTTP_PROTOCOL {
+		client, err = NewHTTPClient(*cfg.GetHTTPConfig())
+		if err != nil {
+			return nil, errno.ERR_HTTP_CONNECT_FAILED.E(err)
+		}
+		return
+	}
+	return
+}

--- a/pkg/module/shell.go
+++ b/pkg/module/shell.go
@@ -79,18 +79,18 @@ const (
 
 // TODO(P1): support command pipe
 type Shell struct {
-	sshClient *SSHClient
-	options   []string
-	tmpl      *template.Template
-	data      map[string]interface{}
+	remoteClient RemoteClient
+	options      []string
+	tmpl         *template.Template
+	data         map[string]interface{}
 }
 
-func NewShell(sshClient *SSHClient) *Shell {
+func NewShell(remoteClient RemoteClient) *Shell {
 	return &Shell{
-		sshClient: sshClient,
-		options:   []string{},
-		tmpl:      nil,
-		data:      map[string]interface{}{},
+		remoteClient: remoteClient,
+		options:      []string{},
+		tmpl:         nil,
+		data:         map[string]interface{}{},
 	}
 }
 
@@ -111,7 +111,7 @@ func (s *Shell) String() (string, error) {
 
 func (s *Shell) Execute(options ExecOptions) (string, error) {
 	s.data["options"] = strings.Join(s.options, " ")
-	return execCommand(s.sshClient, s.tmpl, s.data, options)
+	return execCommand(s.remoteClient, s.tmpl, s.data, options)
 }
 
 // text

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,7 +47,7 @@ backup() {
 }
 
 setup() {
-    mkdir -p "${g_curveadm_home}"/{bin,data,module,logs,temp}
+    mkdir -p "${g_curveadm_home}"/{bin,data,module,logs,conf,temp}
 
     # generate config file
     local confpath="${g_curveadm_home}/curveadm.cfg"
@@ -65,6 +65,18 @@ timeout = 10
 
 [database]
 url = "${g_db_path}"
+__EOF__
+    fi
+
+
+    # generate http service config file
+    local httpConfpath="${g_curveadm_home}/conf/pigeon.yaml"
+    if [ ! -f $httpConfpath ]; then
+        cat << __EOF__ > $httpConfpath
+servers:
+  - name: curveadm
+    log_level: info
+    listen: :11000
 __EOF__
     fi
 }


### PR DESCRIPTION
Issue Number: https://github.com/opencurve/curveadm/issues/328

1.增加http daemon的部署方式，host增加protocol和http port字段
<img width="363" alt="image" src="https://github.com/opencurve/curveadm/assets/7840869/a6939dfa-e403-4ba6-802a-5600957fc818">
<img width="664" alt="image" src="https://github.com/opencurve/curveadm/assets/7840869/24375cfa-380a-4ec6-8151-49fcc15d6f3f">

2.在每个host节点上部署http daemon，可以使用ansible playbook部署，或者在k8s环境下用daemonset部署
<img width="448" alt="image" src="https://github.com/opencurve/curveadm/assets/7840869/11e3ff63-5917-4165-8e39-9496e9110000">

3.部署http daemon后能正常部署curve集群
<img width="465" alt="image" src="https://github.com/opencurve/curveadm/assets/7840869/e2e33c9c-d729-4fe0-841d-c73b4ba8c6c2">

<img width="465" alt="image" src="https://github.com/opencurve/curveadm/assets/7840869/b30e3671-870d-4779-bdb9-d750c537657d">

<img width="465" alt="image" src="https://github.com/opencurve/curveadm/assets/7840869/cea77c36-61c2-42e9-97c6-2a56208d27f7">

遗留问题：目前enter指令不支持http方式