### PR TITLE
playbook(memcache): support instances and instances_sequence

### DIFF
--- a/internal/configure/hosts/hc_get.go
+++ b/internal/configure/hosts/hc_get.go
@@ -29,6 +29,7 @@ import (
 	"github.com/opencurve/curveadm/internal/configure/curveadm"
 	"github.com/opencurve/curveadm/internal/utils"
 	"github.com/opencurve/curveadm/pkg/module"
+	"github.com/opencurve/curveadm/pkg/variable"
 )
 
 func (hc *HostConfig) get(i *comm.Item) interface{} {
@@ -77,6 +78,10 @@ func (hc *HostConfig) GetBecomeUser() string     { return hc.getString(CONFIG_BE
 func (hc *HostConfig) GetLabels() []string       { return hc.labels }
 func (hc *HostConfig) GetEnvs() []string         { return hc.envs }
 
+func (hc *HostConfig) GetInstances() int                 { return hc.instances }
+func (hc *HostConfig) GetInstancesSequence() int         { return hc.instancesSequence }
+func (hc *HostConfig) GetVariables() *variable.Variables { return hc.variables }
+
 func (hc *HostConfig) GetUser() string {
 	user := hc.getString(CONFIG_USER)
 	if user == "${user}" {
@@ -84,7 +89,6 @@ func (hc *HostConfig) GetUser() string {
 	}
 	return user
 }
-
 func (hc *HostConfig) GetSSHConfig() *module.SSHConfig {
 	hostname := hc.GetSSHHostname()
 	if len(hostname) == 0 {

--- a/internal/configure/hosts/variables.go
+++ b/internal/configure/hosts/variables.go
@@ -1,0 +1,46 @@
+package hosts
+
+import (
+	"fmt"
+	"github.com/opencurve/curveadm/internal/errno"
+	"github.com/opencurve/curveadm/pkg/variable"
+)
+
+type Var struct {
+	name     string
+	resolved bool
+}
+
+var (
+	hostVars = []Var{
+		{name: "instances_sequence"},
+	}
+)
+
+func addVariables(hcs []*HostConfig, idx int, vars []Var) error {
+	hc := hcs[idx]
+	for _, v := range vars {
+		err := hc.GetVariables().Register(variable.Variable{
+			Name:  v.name,
+			Value: getValue(v.name, hcs, idx),
+		})
+		if err != nil {
+			return errno.ERR_REGISTER_VARIABLE_FAILED.E(err)
+		}
+	}
+
+	return nil
+}
+
+func AddHostVariables(hcs []*HostConfig, idx int) error {
+	return addVariables(hcs, idx, hostVars)
+}
+
+func getValue(name string, hcs []*HostConfig, idx int) string {
+	hc := hcs[idx]
+	switch name {
+	case "instances_sequence":
+		return fmt.Sprintf("%02d", hc.GetInstancesSequence())
+	}
+	return ""
+}

--- a/internal/errno/errno.go
+++ b/internal/errno/errno.go
@@ -305,7 +305,7 @@ var (
 	ERR_PARSE_HOSTS_FAILED     = EC(320003, "parse hosts failed")
 	// 321: configure (hosts.yaml: invalid configure value)
 	ERR_UNSUPPORT_HOSTS_CONFIGURE_ITEM           = EC(321000, "unsupport hosts configure item")
-	ERR_HOST_FIELD_MISSING                       = EC(321001, "host field missing")
+	ERR_NAME_FIELD_MISSING                       = EC(321001, "name field missing")
 	ERR_HOSTNAME_FIELD_MISSING                   = EC(321002, "hostname field missing")
 	ERR_HOSTS_SSH_PORT_EXCEED_MAX_PORT_NUMBER    = EC(321003, "ssh_port exceed max port number")
 	ERR_PRIVATE_KEY_FILE_REQUIRE_ABSOLUTE_PATH   = EC(321004, "SSH private key file needs to be an absolute path")

--- a/playbook/memcached/hosts_instances.yaml
+++ b/playbook/memcached/hosts_instances.yaml
@@ -1,0 +1,46 @@
+global:
+  user: curve
+  ssh_port: 22
+  private_key_file: /home/curve/.ssh/id_rsa
+
+hosts:
+  - name: server-host1
+    hostname: 10.0.1.1
+    labels:
+      - memcached
+    envs:
+      - SUDO_ALIAS=sudo
+      - ENGINE=docker
+      - IMAGE=memcached:1.6.17
+      - EXPORTER_IMAGE=quay.io/prometheus/memcached-exporter:v0.13.0
+      - LISTEN=10.0.1.1
+      - PORT=112${instances_sequence}
+      - EXPORTER_PORT=91${instances_sequence}
+      - USER=root
+      - MEMORY_LIMIT=32768 # item memory in megabytes
+      - MAX_ITEM_SIZE=8m # adjusts max item size (default: 1m, min: 1k, max: 1024m)
+      - EXT_PATH=/mnt/memcachefile/cachefile:10${instances_sequence}G
+      - EXT_WBUF_SIZE=8 # size in megabytes of page write buffers.
+      - EXT_ITEM_AGE=1 # store items idle at least this long (seconds, default: no age limit)
+      - VERBOSE="v"
+    instances: 3
+
+  - name: server-host2
+    hostname: 10.0.1.2
+    labels:
+      - memcached
+    envs:
+      - SUDO_ALIAS=sudo
+      - ENGINE=docker
+      - IMAGE=memcached:1.6.17
+      - EXPORTER_IMAGE=quay.io/prometheus/memcached-exporter:v0.13.0
+      - LISTEN=10.0.1.2
+      - PORT=11211
+      - EXPORTER_PORT=9151
+      - USER=root
+      - MEMORY_LIMIT=32768 # item memory in megabytes
+      - MAX_ITEM_SIZE=8m # adjusts max item size (default: 1m, min: 1k, max: 1024m)
+      - EXT_PATH=/mnt/memcachefile/cachefile:1024G
+      - EXT_WBUF_SIZE=8 # size in megabytes of page write buffers.
+      - EXT_ITEM_AGE=1 # store items idle at least this long (seconds, default: no age limit)
+      - VERBOSE="v"

--- a/playbook/memcached/scripts/clean.sh
+++ b/playbook/memcached/scripts/clean.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 g_container_name="memcached-"${PORT}
+g_exporter_container_name="memcached-exporter-"${EXPORTER_PORT}
 g_docker_cmd="${SUDO_ALIAS} ${ENGINE}"
 g_rm_cmd="${SUDO_ALIAS} rm -rf"
 
@@ -23,6 +24,13 @@ precheck() {
         die "container [${g_container_name}] not exists!!!\n"
         exit 1
     fi
+    if [ "${EXPORTER_PORT}" ];then
+        container_id=`${g_docker_cmd} ps --all --format "{{.ID}}" --filter name=${g_exporter_container_name}`
+        if [ -z ${container_id} ]; then
+            die "container [${g_exporter_container_name}] not exists!!!\n"
+            exit 1
+        fi
+    fi
 }
 
 stop_container() {
@@ -32,6 +40,14 @@ stop_container() {
         exit 1
     fi
     success "rm container[${g_container_name}]\n"
+    if [ "${EXPORTER_PORT}" ];then
+        msg=`${g_docker_cmd} rm ${g_exporter_container_name}`
+        if [ $? -ne 0 ];then
+            die "${msg}\n"
+            exit 1
+        fi
+        success "rm container[${g_exporter_container_name}]\n"
+    fi
 }
 
 rm_cachefile() {

--- a/playbook/memcached/scripts/deploy.sh
+++ b/playbook/memcached/scripts/deploy.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 g_container_name="memcached-"${PORT}
+g_exporter_container_name="memcached-exporter-"${EXPORTER_PORT}
 g_start_args=""
+g_exporter_start_args=""
 g_docker_cmd="${SUDO_ALIAS} ${ENGINE}"
 g_lsof_cmd="${SUDO_ALIAS} lsof"
 g_rm_cmd="${SUDO_ALIAS} rm -rf"
@@ -28,7 +30,21 @@ precheck() {
     container_id=`${g_docker_cmd} ps --format "{{.ID}}" --filter name=${g_container_name} --all`
     if [ "${container_id}" ]; then
         success "container [${g_container_name}] already exists, skip\n"
-        exit 0
+        exit 1
+    fi
+
+    if [ "${EXPORTER_PORT}" ];then
+        container_id=`${g_docker_cmd} ps --format "{{.ID}}" --filter name=${g_exporter_container_name} --all`
+        if [ "${container_id}" ]; then
+            success "container [${g_exporter_container_name}] already exists, skip\n"
+            exit 1
+        fi
+        
+        ${g_lsof_cmd} -i:${EXPORTER_PORT} >& /dev/null
+        if [ $? -eq 0 ];then
+            die "port[${EXPORTER_PORT}] is in use!\n"
+            exit 1
+        fi
     fi
 
     # check port
@@ -79,14 +95,28 @@ init() {
     if [ "${VERBOSE}" ];then
         g_start_args="${g_start_args} -${VERBOSE}"
     fi
+
+
+    if [ "${EXPORTER_PORT}" ];then
+        g_exporter_start_args="${g_exporter_start_args} --memcached.address=${LISTEN}:${PORT}"
+        g_exporter_start_args="${g_exporter_start_args} --web.listen-address=${LISTEN}:${EXPORTER_PORT}"
+    fi
 }
 
 create_container() {
-    success "create container [${g_container_name}]\n"
     ${g_docker_cmd} create --name ${g_container_name} ${g_user} --network host ${g_volume_bind} ${IMAGE} memcached ${g_start_args} >& /dev/null
-
-    success "start container [${g_container_name}]\n"
+    success "create container [${g_container_name}]\n"
+    if [ "${EXPORTER_PORT}" ];then
+        ${g_docker_cmd} create --name ${g_exporter_container_name} --network host ${EXPORTER_IMAGE} ${g_exporter_start_args} >& /dev/null
+        success "create container [${g_exporter_container_name}]\n"
+    fi
     ${g_docker_cmd} start ${g_container_name} >& /dev/null
+    success "start container [${g_container_name}]\n"
+    if [ "${EXPORTER_PORT}" ];then
+        ${g_docker_cmd} start ${g_exporter_container_name} >& /dev/null
+        success "start container [${g_exporter_container_name}]\n"
+    fi
+
 
     success "wait 3 seconds, check container status...\n"
     sleep 3
@@ -95,14 +125,25 @@ create_container() {
     if [ ${g_status} != "running" ]; then
         exit 1
     fi
+    if [ "${EXPORTER_PORT}" ];then
+        if [ ${g_exporter_status} != "running" ]; then
+            exit 1
+        fi
+    fi
 }
 
 get_status_container() {
     g_status=`${g_docker_cmd} inspect --format='{{.State.Status}}' ${g_container_name}`
+    if [ "${EXPORTER_PORT}" ];then
+        g_exporter_status=`${g_docker_cmd} inspect --format='{{.State.Status}}' ${g_exporter_container_name}`
+    fi
 }
 
 show_info_container() {
     ${g_docker_cmd} ps --all --filter "name=${g_container_name}" --format="table {{.ID}}\t{{.Names}}\t{{.Status}}"
+    if [ "${EXPORTER_PORT}" ];then
+        ${g_docker_cmd} ps --all --filter "name=${g_exporter_container_name}" --format="table {{.ID}}\t{{.Names}}\t{{.Status}}"
+    fi
 }
 
 precheck

--- a/playbook/memcached/scripts/start.sh
+++ b/playbook/memcached/scripts/start.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 g_container_name="memcached-"${PORT}
+g_exporter_container_name="memcached-exporter-"${EXPORTER_PORT}
 g_docker_cmd="${SUDO_ALIAS} ${ENGINE}"
 g_rm_cmd="${SUDO_ALIAS} rm -rf"
 g_mkdir_cmd="${SUDO_ALIAS} mkdir -p"
@@ -34,6 +35,10 @@ precheck() {
 start_container() {
     ${g_docker_cmd} start ${g_container_name} >& /dev/null
     success "start container[${g_container_name}]\n"
+    if [ "${EXPORTER_PORT}" ];then
+        ${g_docker_cmd} start ${g_exporter_container_name} >& /dev/null
+        success "start container[${g_exporter_container_name}]\n"
+    fi
 }
 
 get_status_container() {

--- a/playbook/memcached/scripts/status.sh
+++ b/playbook/memcached/scripts/status.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 g_container_name="memcached-"${PORT}
+g_exporter_container_name="memcached-exporter-"${EXPORTER_PORT}
 g_start_args=""
 g_docker_cmd="${SUDO_ALIAS} ${ENGINE}"
 g_volume_bind=""
 g_container_id=""
-g_status="running"
 
 function msg() {
     printf '%b' "$1" >&2
@@ -26,20 +26,39 @@ precheck() {
         success "container [${g_container_name}] not exists!!!"
         exit 1
     fi
+    if [ "${EXPORTER_PORT}" ];then
+        g_container_id=`${g_docker_cmd} ps --all --format "{{.ID}}" --filter name=${g_exporter_container_name}`
+        if [ -z ${g_container_id} ]; then
+            success "container [${g_exporter_container_name}] not exists!!!"
+            exit 1
+        fi
+    fi
 }
 
 show_info_container() {
     ${g_docker_cmd} ps --all --filter "name=${g_container_name}" --format="table {{.ID}}\t{{.Names}}\t{{.Status}}"
+    if [ "${EXPORTER_PORT}" ];then
+        ${g_docker_cmd} ps --all --filter "name=${g_exporter_container_name}" --format="table {{.ID}}\t{{.Names}}\t{{.Status}}"
+    fi
 }
 
 show_ip_port() {
     printf "memcached addr:\t%s:%d\n" ${LISTEN} ${PORT}
+    if [ "${EXPORTER_PORT}" ];then
+        printf "memcached-exporter addr:\t%s:%d\n" ${LISTEN} ${EXPORTER_PORT}
+    fi
 }
 
 get_status_container() {
-    g_status=`${g_docker_cmd} inspect --format='{{.State.Status}}' ${g_container_name}`
-    if [ ${g_status} != "running" ]; then
+    status=`${g_docker_cmd} inspect --format='{{.State.Status}}' ${g_container_name}`
+    if [ ${status} != "running" ]; then
             exit 1
+    fi
+    if [ "${EXPORTER_PORT}" ];then
+        status=`${g_docker_cmd} inspect --format='{{.State.Status}}' ${g_exporter_container_name}`
+        if [ ${status} != "running" ]; then
+            exit 1
+        fi
     fi
 }
 

--- a/playbook/memcached/scripts/stop.sh
+++ b/playbook/memcached/scripts/stop.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 g_container_name="memcached-"${PORT}
+g_exporter_container_name="memcached-exporter-"${EXPORTER_PORT}
 g_docker_cmd="${SUDO_ALIAS} ${ENGINE}"
 
 function msg() {
@@ -22,11 +23,22 @@ precheck() {
         die "container [${g_container_name}] not exists!!!\n"
         exit 1
     fi
+    if [ "${EXPORTER_PORT}" ];then
+        container_id=`${g_docker_cmd} ps --all --format "{{.ID}}" --filter name=${g_exporter_container_name}`
+        if [ -z ${container_id} ]; then
+            die "container [${g_exporter_container_name}] not exists!!!\n"
+            exit 1
+        fi
+    fi
 }
 
 stop_container() {
     ${g_docker_cmd} stop ${g_container_name} >& /dev/null
     success "stop container[${g_container_name}]\n"
+    if [ "${EXPORTER_PORT}" ];then
+        ${g_docker_cmd} stop ${g_exporter_container_name} >& /dev/null
+        success "stop container[${g_exporter_container_name}]\n"
+    fi
 }
 
 precheck


### PR DESCRIPTION
fix #240 
1. hosts.yaml support the instances and {instances_sequence}. 
2. add the hosts_instances.yaml as a template. 
3. playbook memcached add exporter (from tombstone branch)

Now, when deploying the memcached cluster, hosts.yaml can be written as follows：
```
global:
  user: curve
  ssh_port: 22
  private_key_file: /home/curve/.ssh/id_rsa
  
hosts:
  - name: server-host1
    hostname: 10.0.1.1
    labels:
      - memcached
    envs:
      - SUDO_ALIAS=sudo
      - ENGINE=docker
      - IMAGE=memcached:1.6.17
      - EXPORTER_IMAGE=quay.io/prometheus/memcached-exporter:v0.13.0
      - LISTEN=10.0.1.1
      - PORT=112${instances_sequence}
      - EXPORTER_PORT=91${instances_sequence}
      - USER=root
      - MEMORY_LIMIT=32768 # item memory in megabytes
      - MAX_ITEM_SIZE=8m # adjusts max item size (default: 1m, min: 1k, max: 1024m)
      - EXT_PATH=/mnt/memcachefile/cachefile:10${instances_sequence}G
      - EXT_WBUF_SIZE=8 # size in megabytes of page write buffers.
      - EXT_ITEM_AGE=1 # store items idle at least this long (seconds, default: no age limit)
      - VERBOSE="v"
    instances: 3

  - name: server-host2
    hostname: 10.0.1.2
    labels:
      - memcached
    envs:
      - SUDO_ALIAS=sudo
      - ENGINE=docker
      - IMAGE=memcached:1.6.17
      - EXPORTER_IMAGE=quay.io/prometheus/memcached-exporter:v0.13.0
      - LISTEN=10.0.1.2
      - PORT=11211
      - EXPORTER_PORT=9151
      - USER=root
      - MEMORY_LIMIT=32768 # item memory in megabytes
      - MAX_ITEM_SIZE=8m # adjusts max item size (default: 1m, min: 1k, max: 1024m)
      - EXT_PATH=/mnt/memcachefile/cachefile:1024G
      - EXT_WBUF_SIZE=8 # size in megabytes of page write buffers.
      - EXT_ITEM_AGE=1 # store items idle at least this long (seconds, default: no age limit)
      - VERBOSE="v"
```
